### PR TITLE
bug fixed about abortion when using escape sequence in debug mode

### DIFF
--- a/src/sugar/sugarfunc.h
+++ b/src/sugar/sugarfunc.h
@@ -33,7 +33,7 @@ static kString *resolveEscapeSequence(KonohaContext *kctx, kString *s, size_t st
 {
 	const char *text = S_text(s) + start;
 	size_t i;
-	int ch, next;
+	int ch, next = 0;
 	KUtilsWriteBuffer wb;
 	KLIB Kwb_init(&(kctx->stack->cwb), &wb);
 	KLIB Kwb_write(kctx, &wb, S_text(s), start);


### PR DESCRIPTION
Fixed a bug about abortion when using escape sequence with KONOHA_DEBUG=on;

<pre>
$ cat escape.k
p("\n");
$ export KONOHA_DEBUG=on
$ minikonoha escape.k
...
zsh: abort      minikonoha escape.k
</pre>
