### PR TITLE
comment out konoha.global package import in konoha_initNameSpace

### DIFF
--- a/package/konoha/konoha_glue.c
+++ b/package/konoha/konoha_glue.c
@@ -67,7 +67,7 @@ static kbool_t konoha_initNameSpace(KonohaContext *kctx, kNameSpace *ns, kfileli
 	KEXPORT_PACKAGE("konoha.assignment", ns, pline);
 	KEXPORT_PACKAGE("konoha.while", ns, pline);
 	KEXPORT_PACKAGE("konoha.class", ns, pline);
-	KEXPORT_PACKAGE("konoha.global", ns, pline);
+	//KEXPORT_PACKAGE("konoha.global", ns, pline);
 
 	KEXPORT_PACKAGE("konoha.null", ns, pline);
 	KEXPORT_PACKAGE("konoha.int", ns, pline);


### PR DESCRIPTION
Importing konoha package in package script (packagename_glue.k) causes warning like

<pre> - (warning) conflicted name: Script</pre>

To avoid warning, I commented out konoha.global package import in konoha_initNameSpace.
