### PR TITLE
fix new expr bug and method outside declaration bug

### DIFF
--- a/src/sugar/ast.h
+++ b/src/sugar/ast.h
@@ -371,7 +371,7 @@ static kExpr *ParseExpr(KonohaContext *kctx, kStmt *stmt, kArray *tokenArray, in
 		int i;
 		kArray *a = (kArray*)fo;
 		for(i = kArray_size(a) - 1; i > 0; i--) {
-			texpr = ParseExprFunc(kctx, syn, fo, stmt, tokenArray, beginIdx, currentIdx, endIdx);
+			texpr = ParseExprFunc(kctx, syn, a->funcItems[i], stmt, tokenArray, beginIdx, currentIdx, endIdx);
 			if(Stmt_isERR(stmt)) return K_NULLEXPR;
 			if(texpr != K_NULLEXPR) return texpr;
 		}
@@ -585,7 +585,7 @@ static int PatternMatch(KonohaContext *kctx, SugarSyntax *syn, kStmt *stmt, ksym
 		int i;
 		kArray *a = (kArray*)fo;
 		for(i = kArray_size(a) - 1; i > 0; i--) {
-			next = PatternMatchFunc(kctx, fo, stmt, name, tokenList, beginIdx, endIdx);
+			next = PatternMatchFunc(kctx, a->funcItems[i], stmt, name, tokenList, beginIdx, endIdx);
 			if(Stmt_isERR(stmt)) return -1;
 			if(next > beginIdx) return next;
 		}
@@ -679,8 +679,8 @@ static int kStmt_matchSyntaxRule(KonohaContext *kctx, kStmt *stmt, kArray *token
 	if(currentTokenIdx < endIdx) {
 		if(!canRollBack) {
 			kStmt_p(stmt, ErrTag, "%s%s: unexpected token %s", T_statement(stmt->syn->keyword), Token_text(tokenList->tokenItems[currentTokenIdx]));
+			return returnIdx;
 		}
-		return returnIdx;
 	}
 	return currentTokenIdx;
 }

--- a/src/sugar/sugarfunc.h
+++ b/src/sugar/sugarfunc.h
@@ -1133,8 +1133,9 @@ static ktype_t kStmt_getClassId(KonohaContext *kctx, kStmt *stmt, kNameSpace *ns
 		return defcid;
 	}
 	else {
-		DBG_ASSERT(TK_isType(tk));
-		return TK_type(tk);
+		KonohaClass *ct = kNameSpace_getClass(kctx, ns, S_text(tk->text), S_size(tk->text), NULL);
+		DBG_ASSERT(ct != NULL);
+		return ct->classId;
 	}
 }
 
@@ -1227,8 +1228,8 @@ static void defineDefaultSyntax(KonohaContext *kctx, kNameSpace *ns)
 		{ TOKEN(LET),  .flag = SYNFLAG_ExprLeftJoinOp2, ParseExpr_(Op), .precedence_op2 = 4096, },
 		{ TOKEN(COMMA), ParseExpr_(COMMA), .precedence_op2 = 8192, },
 		{ TOKEN(DOLLAR), ParseExpr_(DOLLAR), },
-//		{ TOKEN(void), .type = TY_void, .rule ="$type [type: $type \".\"] $SYMBOL $params [$block]", TopStmtTyCheck_(MethodDecl)},
-		{ TOKEN(void), .type = TY_void, .rule ="$type $SYMBOL $params [$block]", TopStmtTyCheck_(MethodDecl)},
+		{ TOKEN(void), .type = TY_void, .rule ="$type [type: $SYMBOL \".\"] $SYMBOL $params [$block]", TopStmtTyCheck_(MethodDecl)},
+//		{ TOKEN(void), .type = TY_void, .rule ="$type $SYMBOL $params [$block]", TopStmtTyCheck_(MethodDecl)},
 		{ TOKEN(boolean), .type = TY_Boolean, },
 		{ TOKEN(int),     .type = TY_Int, },
 		{ TOKEN(true),  _TERM, ExprTyCheck_(true),},


### PR DESCRIPTION
fixed following bugs.
- new expression
  <pre>
  class A {
  int x;
  }
  A a = new A();
  // => - (error) ((shell):4) undefined class: A
  </pre>
- method outside declaration
  <pre>
  void String.f() {
  p(this);
  }
  // => - (error) ((shell):5) function declaration expects $params
  </pre>
