### PR TITLE
add @Public annotation

### DIFF
--- a/package/konoha.class/test/Experimental/FinalMethod.k
+++ b/package/konoha.class/test/Experimental/FinalMethod.k
@@ -5,13 +5,13 @@ K.import("konoha.assign");
 
 class C {
 	int x;
-	@Final int succ() {
+	@Public @Final int succ() {
 		return x;
 	}
 }
 
 class D extends C {
-	@Override int succ() {
+	@Public @Override int succ() {
 		return x + 1;
 	}
 }


### PR DESCRIPTION
- Private method cannot be referenced from derived class.
- User defined class method is treated as private method by default.
- So I add @Public annotation into override test and it looks like work fine.
