### PR TITLE
impl error process at System.stat()

### DIFF
--- a/package/posix.fd/fd_glue.c
+++ b/package/posix.fd/fd_glue.c
@@ -464,6 +464,7 @@ static KMETHOD System_stat(KonohaContext *kctx, KonohaStack *sfp)
 	}
 	else {
 		// TODO: throw
+		RETURN_(KLIB Knull(kctx, O_ct(sfp[K_RTNIDX].o)));
 	}
 	RETURN_(stat);
 }


### PR DESCRIPTION
- fix a bug that `System.stat("/not/exist")` causes segmantation fault
