### PR TITLE
remove unnecessary header

### DIFF
--- a/package/konoha.bytes/bytes_glue.c
+++ b/package/konoha.bytes/bytes_glue.c
@@ -26,7 +26,6 @@
 #include <minikonoha/sugar.h>
 
 #include <stdio.h>
-#include <minikonoha/logger.h>
 #include <minikonoha/bytes.h>
 
 #include <errno.h> // include this because of E2BIG


### PR DESCRIPTION
Removed `#include <minikonoha/logger.h>` since make of konoha.bytes package fails if minikonoha/logger.h is not installed.
