### PR TITLE
fix sugar syntaxpattern bug, add Block.tyCheckAll test

### DIFF
--- a/package/sugar/test/BlockTyCheckAll.k
+++ b/package/sugar/test/BlockTyCheckAll.k
@@ -1,0 +1,30 @@
+// written by chenji
+
+import("konoha.null");
+import("sugar");
+
+syntax "hoge" $Block;
+
+boolean tyCheckHoge(Stmt stmt, Gamma gma) {
+	Block b = stmt.getBlock("$Block", null);
+	boolean ret = false;
+	if(b != null) {
+		ret = b.tyCheckAll(gma);
+		if(ret) {
+			stmt.setType(TSTMT_BLOCK);
+		}
+	}
+	return ret;
+}
+
+addStatement("hoge", tyCheckHoge);
+
+void test() {
+	boolean executed = false;
+	hoge {
+		executed = true;
+	}
+	assert(executed);
+}
+
+test();

--- a/src/sugar/ast.h
+++ b/src/sugar/ast.h
@@ -710,7 +710,7 @@ static int kStmt_parseBySyntaxPattern(KonohaContext *kctx, kStmt *stmt, int inde
 		if(currentSyntax->SyntaxPatternListNULL != NULL) {
 			int patternEndIdx = kArray_size(currentSyntax->SyntaxPatternListNULL);
 			TokenSequence tokens = {ns, tokenList, beginIdx, endIdx};
-			TokenSequence nrule  = {ns, currentSyntax->SyntaxPatternListNULL};
+			TokenSequence nrule  = {ns, currentSyntax->SyntaxPatternListNULL, 0, kArray_size(currentSyntax->SyntaxPatternListNULL)};
 			do {
 				patternEndIdx = TokenSequence_selectSyntaxPattern(kctx, &nrule, currentSyntax->SyntaxPatternListNULL, patternEndIdx);
 				errRule[0] = NULL; errRule[1] = NULL;


### PR DESCRIPTION
- Fix a bug that fails assertion at line 725 of `src/sugar/ast.h`.
  `DBG_ASSERT(errRule[0] != NULL);`
- Add sugar test (Block.tyCheckAll).
- Remove unnecessary proof file.
