### PR TITLE
bugs fixed ad Bytes.setAll()

### DIFF
--- a/package/konoha.bytes/bytes_glue.c
+++ b/package/konoha.bytes/bytes_glue.c
@@ -120,7 +120,7 @@ static KMETHOD Bytes_setAll(KonohaContext *kctx, KonohaStack *sfp)
 {
 	kBytes *ba = sfp[0].asBytes;
 	int bytesize = ba->bytesize;
-	memset(ba->buf, sfp[2].intValue, bytesize);
+	memset(ba->buf, sfp[1].intValue, bytesize);
 	KReturnVoid();
 }
 

--- a/package/konoha.bytes/test/BytesSetAll.k
+++ b/package/konoha.bytes/test/BytesSetAll.k
@@ -1,0 +1,22 @@
+/* written by motoki yoan */
+
+import("konoha.new");
+import("konoha.bytes");
+
+void test() {
+	int size = 8;
+	int ascii_a = 97 // 'a'
+	int ascii_b = 98 // 'b'
+	int ascii_c = 99 // 'c'
+	Bytes a = new Bytes(size);
+	Bytes b = new Bytes(size);
+	Bytes c = new Bytes(size);
+	a.setAll(ascii_a);
+	b.setAll(ascii_b);
+	c.setAll(ascii_c);
+	assert(a.get(0) == ascii_a);
+	assert(b.get(0) == ascii_b);
+	assert(c.get(0) == ascii_c);
+}
+
+test();


### PR DESCRIPTION
I fiexed bug of Bytes.setAll(int c).
this method should be set sfp[1](int c), but it set sfp[2].
