### PR TITLE
define json_boolean macro if jansson version is under 2.4.0

### DIFF
--- a/module/Jansson/Jansson.c
+++ b/module/Jansson/Jansson.c
@@ -52,6 +52,10 @@ static void SetJsonBuf(struct JsonBuf *jsonbuf, json_t *json)
 	jsonbuf->jsonobj = json;
 }
 
+#if JANSSON_VERSION_HEX < 0x020400
+#define json_boolean(val)      ((val) ? json_true() : json_false())
+#endif /* JANSSON_VERSION_HEX < 0x020400 */
+
 static json_t* NewJsonRef(KJSONTYPE type, va_list ap)
 {
 	json_t *newref = NULL;

--- a/package/mecab/mecab_glue.c
+++ b/package/mecab/mecab_glue.c
@@ -106,7 +106,7 @@ static KMETHOD Tagger_NBestInit(KonohaContext *kctx, KonohaStack *sfp)
 {
 	struct _kTagger *mecab = (struct _kTagger *)sfp[0].asObject;
 	const char *input = S_text(sfp[1].asString);
-	KReturnUnboxValue(mecab_nbest_Init(mecab->mecab, input));
+	KReturnUnboxValue(mecab_nbest_init(mecab->mecab, input));
 }
 
 // String Tagger.NBestNext()
@@ -329,7 +329,7 @@ static KMETHOD MecabNode_cost(KonohaContext *kctx, KonohaStack *sfp)
 
 /* ------------------------------------------------------------------------ */
 
-static kbool_t mecab_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int argc, const char **args, KTraceInfo *trace)
+static kbool_t mecab_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int option, KTraceInfo *trace)
 {
 	static KDEFINE_CLASS TaggerDef = {
 		STRUCTNAME(Tagger),


### PR DESCRIPTION
revert wrong refactoring of mecab api
