### PR TITLE
enabled -c option on JavaScript module

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -74,4 +74,8 @@
 #cmakedefine HAVE_BUILTIN_CTZL 1
 
 /* Define to 1 if you have the `bzero' function. */
-#cmakedefine HAVE_BZERO 1
+#cmakedefine HAVE_BZERO 1 
+
+/* Define to 1 if you have the `bzero' function. */
+#cmakedefine HAVE_LIBV8 1
+

--- a/module/JavaScript/CMakeLists.txt
+++ b/module/JavaScript/CMakeLists.txt
@@ -1,8 +1,7 @@
 ## written by tetz
 find_library(HAVE_LIBV8 NAMES v8)
 if(HAVE_LIBV8)
-	set(MODULE_SOURCE_CODE JavaScript.cpp)
 	set(MODULE_EXTRA_LIBRARY ${HAVE_LIBV8})
-	add_konoha_module(JavaScript)
 endif(HAVE_LIBV8)
-
+set(MODULE_SOURCE_CODE JavaScript.cpp)
+add_konoha_module(JavaScript)


### PR DESCRIPTION
Enabled -c option on JavaScript module.
It is always enabled with no libv8.
