### PR TITLE
fix a string bug that occurs when using both dshell and Json module

### DIFF
--- a/src/module/Json/kjson/kjson.h
+++ b/src/module/Json/kjson/kjson.h
@@ -336,7 +336,8 @@ static inline JSON JSONString_new(JSONMemoryPool *jm, const char *s, size_t len)
     JSONString *o = (JSONString *) JSONMemoryPool_Alloc(jm, sizeof(*o), &malloced);
     JSON json = toJSON(ValueS(o));
     JSON_Init(json);
-    char *str = (len > JSONSTRING_INLINE_SIZE) ? (char *) malloc(len) : o->text;
+    char *str = (len > JSONSTRING_INLINE_SIZE) ? (char *) malloc(len + 1) : o->text;
+    str[len] = '\0';
     memcpy(str, s, len);
     JSONString_init(o, (const char *)str, len);
     return json;

--- a/src/package-devel/dshell/dshell_glue.k
+++ b/src/package-devel/dshell/dshell_glue.k
@@ -265,8 +265,14 @@ boolean statementShell(Stmt stmt, Gamma gma) {
 int patternMatchShell(Stmt stmt, int nameid, Token[] tokenList, int beginIdx, int endIdx) {
 	Token firstToken = tokenList[beginIdx];
 	if(firstToken.Is("$Symbol") && SubProc.isCommand(firstToken.getText())) {
+		if(firstToken.getText() == "Expr") {
+			return -1;
+		}
 		int i = beginIdx + 1;
 		while(i < endIdx) {
+			if(tokenList[i].is("$Indent") || tokenList[i].getText() == ";") {
+				break;
+			}
 			if(tokenList[i].Is("()")) {
 				return -1;
 			}
@@ -422,7 +428,7 @@ AddTopLevelStatement("$Shell", statementShell);
 AddExpression("ask", expressionAsk);
 AddTypeCheck("$Text", typeCheckStringInterpolation);
 
-syntax $Shell $Token*
+syntax $Shell $Token*;
 
 AddTokenizer("$DollarVariable", 36/*KonohaChar_Dollar*/, tokenFuncDollarVariable);
 AddExpression("$DollarVariable", expressionDollarVariable);

--- a/src/package/konoha.desugar/desugar_glue.c
+++ b/src/package/konoha.desugar/desugar_glue.c
@@ -180,6 +180,9 @@ static KMETHOD Token_Is(KonohaContext *kctx, KonohaStack *sfp)
 {
 	kTokenVar *tk = (kTokenVar *)sfp[0].asToken;
 	ksymbol_t keyword = (ksymbol_t)sfp[1].intValue;
+	if(keyword == KSymbol_("$Indent") && tk->resolvedSymbol == TokenType_INDENT) {
+		KReturnUnboxValue(true);
+	}
 	KReturnUnboxValue(tk->resolvedSyntaxInfo != NULL && tk->resolvedSyntaxInfo->keyword == keyword);
 }
 


### PR DESCRIPTION
fix a string bug that occurs when using both dshell and Json module.
if over 16 bytes of string is passed to json value, it becomes incorrect string. 
- input

```
import("dshell");
import("konoha.json");

void test() {
    Json j = new Json();
    j.setString("16bytes", "0123456789012345");
    System.p(j.getString("16bytes"));
    j.setString("17bytes", "01234567890123456");
    System.p(j.getString("17bytes"));
}

test();
```
- output

```
 - (js.k:7) 0123456789012345
 - (js.k:9) 01234567890123456r/sbin:/sbin
```
