### PR TITLE
Libevent package 暫定版

### DIFF
--- a/src/package-devel/libevent/CMakeLists.txt
+++ b/src/package-devel/libevent/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
 FIND_PACKAGE_EXTRA_LIBRARY(event)
-set(PACKAGE_SOURCE_CODE libevent_glue.c)
-set(PACKAGE_SCRIPT_CODE libevent_glue.k)
+set(PACKAGE_SOURCE_CODE libevent_glue.c libevent_event_glue.c)
+set(PACKAGE_SCRIPT_CODE libevent_glue.k libevent_event_glue.k)
 add_konoha_package(libevent)

--- a/src/package-devel/libevent/CMakeLists.txt
+++ b/src/package-devel/libevent/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.6)
+FIND_PACKAGE_EXTRA_LIBRARY(event)
+set(PACKAGE_SOURCE_CODE libevent_glue.c)
+set(PACKAGE_SCRIPT_CODE libevent_glue.k)
+add_konoha_package(libevent)

--- a/src/package-devel/libevent/libevent_event_glue.c
+++ b/src/package-devel/libevent/libevent_event_glue.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012, the Konoha project authors. All rights reserved.
+ * Copyright (c) 2013, the Konoha project authors. All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/src/package-devel/libevent/libevent_event_glue.c
+++ b/src/package-devel/libevent/libevent_event_glue.c
@@ -80,14 +80,16 @@ static kbool_t Libevent_event_PackupNameSpace(KonohaContext *kctx, kNameSpace *n
 	};
 	KLIB kNameSpace_LoadMethodData(kctx, ns, MethodData, trace);
 
-#ifdef	CUTCUT
-	/* You can define constant variable with the following procedures. */
 	KDEFINE_INT_CONST IntData[] = {
-		{"NARUTO_AGE", KType_int, 18},
+		{KDefineConstInt(EV_TIMEOUT)},
+		{KDefineConstInt(EV_READ)},
+		{KDefineConstInt(EV_WRITE)},
+		{KDefineConstInt(EV_SIGNAL)},
+		{KDefineConstInt(EV_PERSIST)},
+		{KDefineConstInt(EV_ET)},
 		{} /* <= sentinel */
 	};
 	KLIB kNameSpace_LoadConstData(kctx, ns, KConst_(IntData), false/*isOverride*/, trace);
-#endif
 	return true;
 }
 
@@ -106,23 +108,5 @@ KDEFINE_PACKAGE *libevent_event_Init(void)
 }
 
 #ifdef __cplusplus
-}
-#endif
-
-
-
-#if CUTCUT
-//## String Person.say();
-static KMETHOD Libevent_event_add(KonohaContext *kctx, KonohaStack *sfp)
-{
-	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
-
-	kString *name = p->name;
-	/* When you want to operate with a raw string, please use kString_text() macro
-	 * to acquire the pointer of a raw string. */
-	const char *text = kString_text(name);
-	char *buf = (char *)alloca(16 + kString_size(name));
-	sprintf(buf, "hello , %s!", text);
-	KReturn(KLIB new_kString(kctx, OnStack, buf, strlen(buf), StringPolicy_TEXT));
 }
 #endif

--- a/src/package-devel/libevent/libevent_event_glue.c
+++ b/src/package-devel/libevent/libevent_event_glue.c
@@ -32,80 +32,50 @@
 extern "C" {
 #endif
 
-static void Libevent_Init(KonohaContext *kctx, kObject *o, void *conf)
+static void Libevent_event_Init(KonohaContext *kctx, kObject *o, void *conf)
 {
-	struct Libevent *ev = (struct Libevent *) o;
-	ev->event_base = NULL/*?*/;	//refered jansson_glue.c
+	struct Libevent_event *ev = (struct Libevent_event *) o;
+	ev->event = NULL;
 }
 
-static void Libevent_Free(KonohaContext *kctx, kObject *o)
+static void Libevent_event_Free(KonohaContext *kctx, kObject *o)
 {
-	struct Libevent *ev = (struct Libevent *) o;
+	struct Libevent_event *ev = (struct Libevent_event *) o;
 
-	if (ev->event_base != NULL) {
-		event_base_free(ev->event_base);
-		ev->event_base = NULL;
+	if (ev->event != NULL) {
+		event_free(ev->event);
+		ev->event = NULL;
 	}
 }
 
-static void Libevent_p(KonohaContext *kctx, KonohaValue *v, int pos, KBuffer *wb)
+//## Libevent_event Libevent_event.new();
+static KMETHOD Libevent_event_new(KonohaContext *kctx, KonohaStack *sfp)
 {
-#if 0	
-	/*
-	Is event_base able to serialize?
-	e.g. including FileDescriptor, kqueue...
-	*/
-
-	/* This function is called when serializing the object. */
-	struct Person *p = (struct Person *) v[pos].asObject;
-	KLIB KBuffer_Write(kctx, wb, kString_text(p->name), kString_size(p->name));
-	KLIB KBuffer_Write(kctx, wb, ",", 1);
-	KLIB KBuffer_printf(kctx, wb, KINT_FMT, p->age);
-#endif
-}
-
-static void Libevent_Reftrace(KonohaContext *kctx, kObject *o, KObjectVisitor *visitor)
-{
-#if 0
-	/* Garbage collector (GC) cannot recognize in which position of the field
-	 * an object exists. The function tells to GC which object should be traced. */
-	struct Person *p = (struct Person *) o;
-	/* If p->some_field is Nullable, please use 
-	 * KRefTraceNullable() macro instead of KRefTrace(). */
-	KRefTrace(p->name);
-	/* It is not necessary to trace p->age field,
-	 * because p->age is not an Object */
-#endif
-}
-
-//## Libevent Libevent.new();
-static KMETHOD Libevent_new(KonohaContext *kctx, KonohaStack *sfp)
-{
-	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
-	ev->event_base = event_base_new();
+	struct Libevent_event *ev = (struct Libevent_event *) sfp[0].asObject;
+	struct Libevent *libevent = (struct Libevent *)sfp[1].asObject;
+	evutil_socket_t fd = (evutil_socket_t)sfp[2].intValue;
+	kint_t what = sfp[3].intValue;
+	event_callback_fn cb = (event_callback_fn)sfp[4].asFunc;
+	void *arg = (void *)sfp[5].asObject;
+	ev->event = event_new(libevent->event_base, fd, (short)what, cb, arg);
 	KReturn(ev);
 }
-static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int option, KTraceInfo *trace)
+static kbool_t Libevent_event_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int option, KTraceInfo *trace)
 {
 	/* Class Definition */
 	/* If you want to create Generic class like Array<T>, see konoha.map package */
-	KDEFINE_CLASS defLibevent = {0};
-	SETSTRUCTNAME(defLibevent, Libevent);
-	defLibevent.cflag     = KClassFlag_Final;
-	defLibevent.init      = Libevent_Init;
-	defLibevent.p         = Libevent_p;
-	defLibevent.reftrace  = Libevent_Reftrace;
-	defLibevent.free      = Libevent_Free;
-	KClass *LibeventClass = KLIB kNameSpace_DefineClass(kctx, ns, NULL, &defLibevent, trace);
+	KDEFINE_CLASS defLibevent_event = {0};
+	SETSTRUCTNAME(defLibevent_event, Libevent_event);
+	defLibevent_event.cflag     = KClassFlag_Final;
+	defLibevent_event.init      = Libevent_event_Init;
+	defLibevent_event.free      = Libevent_event_Free;
+	KClass *Libevent_eventClass = KLIB kNameSpace_DefineClass(kctx, ns, NULL, &defLibevent_event, trace);
 
 	/* You can define methods with the following procedures. */
-	int KType_Libevent = LibeventClass->typeId;
+	int KType_Libevent_event = Libevent_eventClass->typeId;
 
 	KDEFINE_METHOD MethodData[] = {
-		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"), 0,
-#ifdef	CUTCUT
-		_Public, _F(Person_say), KType_String, KType_Person, KKMethodName_("say"), 0,
-#endif
+		_Public, _F(Libevent_event_new), KType_Libevent_event, KType_Libevent_event, KKMethodName_("new"), 0,
 		DEND, /* <= sentinel */
 	};
 	KLIB kNameSpace_LoadMethodData(kctx, ns, MethodData, trace);
@@ -121,17 +91,17 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	return true;
 }
 
-static kbool_t Libevent_ExportNameSpace(KonohaContext *kctx, kNameSpace *ns, kNameSpace *exportNS, int option, KTraceInfo *trace)
+static kbool_t Libevent_event_ExportNameSpace(KonohaContext *kctx, kNameSpace *ns, kNameSpace *exportNS, int option, KTraceInfo *trace)
 {
 	return true;
 }
 
-KDEFINE_PACKAGE *libevent_Init(void)
+KDEFINE_PACKAGE *libevent_event_Init(void)
 {
 	static KDEFINE_PACKAGE d = {0};
 	KSetPackageName(d, "libevent2", "0.1");
-	d.PackupNameSpace    = Libevent_PackupNameSpace;
-	d.ExportNameSpace   = Libevent_ExportNameSpace;
+	d.PackupNameSpace    = Libevent_event_PackupNameSpace;
+	d.ExportNameSpace   = Libevent_event_ExportNameSpace;
 	return &d;
 }
 

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -90,7 +90,7 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	/* If you want to create Generic class like Array<T>, see konoha.map package */
 	KDEFINE_CLASS defLibevent = {0};
 	SETSTRUCTNAME(defLibevent, Libevent);
-	defLibevent.cflag     = KClassFlag_Final;
+	//defLibevent.cflag     = KClassFlag_Final;
 	defLibevent.init      = Libevent_Init;
 	defLibevent.free      = Libevent_Free;
 	KClass *LibeventClass = KLIB kNameSpace_DefineClass(kctx, ns, NULL, &defLibevent, trace);

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -106,7 +106,7 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	int KType_Libevent = LibeventClass->typeId;
 
 	KDEFINE_METHOD MethodData[] = {
-		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"),
+		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"), 0,
 #ifdef	CUTCUT
 		_Public, _F(Person_say), KType_String, KType_Person, KKMethodName_("say"), 0,
 #endif
@@ -114,12 +114,14 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	};
 	KLIB kNameSpace_LoadMethodData(kctx, ns, MethodData, trace);
 
+#ifdef	CUTCUT
 	/* You can define constant variable with the following procedures. */
 	KDEFINE_INT_CONST IntData[] = {
 		{"NARUTO_AGE", KType_int, 18},
 		{} /* <= sentinel */
 	};
 	KLIB kNameSpace_LoadConstData(kctx, ns, KConst_(IntData), false/*isOverride*/, trace);
+#endif
 	return true;
 }
 
@@ -131,7 +133,7 @@ static kbool_t Libevent_ExportNameSpace(KonohaContext *kctx, kNameSpace *ns, kNa
 KDEFINE_PACKAGE *libevent_Init(void)
 {
 	static KDEFINE_PACKAGE d = {0};
-	KSetPackageName(d, "Libevent2", "0.1");
+	KSetPackageName(d, "libevent2", "0.1");
 	d.PackupNameSpace    = Libevent_PackupNameSpace;
 	d.ExportNameSpace   = Libevent_ExportNameSpace;
 	return &d;

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -35,7 +35,7 @@ extern "C" {
 static void Libevent_Init(KonohaContext *kctx, kObject *o, void *conf)
 {
 	struct Libevent *ev = (struct Libevent *) o;
-	ev->event_base = NULL/*?*/;	//refered jansson_glue.c
+	ev->event_base = NULL;
 }
 
 static void Libevent_Free(KonohaContext *kctx, kObject *o)
@@ -48,43 +48,33 @@ static void Libevent_Free(KonohaContext *kctx, kObject *o)
 	}
 }
 
-static void Libevent_p(KonohaContext *kctx, KonohaValue *v, int pos, KBuffer *wb)
-{
-#if 0	
-	/*
-	Is event_base able to serialize?
-	e.g. including FileDescriptor, kqueue...
-	*/
-
-	/* This function is called when serializing the object. */
-	struct Person *p = (struct Person *) v[pos].asObject;
-	KLIB KBuffer_Write(kctx, wb, kString_text(p->name), kString_size(p->name));
-	KLIB KBuffer_Write(kctx, wb, ",", 1);
-	KLIB KBuffer_printf(kctx, wb, KINT_FMT, p->age);
-#endif
-}
-
-static void Libevent_Reftrace(KonohaContext *kctx, kObject *o, KObjectVisitor *visitor)
-{
-#if 0
-	/* Garbage collector (GC) cannot recognize in which position of the field
-	 * an object exists. The function tells to GC which object should be traced. */
-	struct Person *p = (struct Person *) o;
-	/* If p->some_field is Nullable, please use 
-	 * KRefTraceNullable() macro instead of KRefTrace(). */
-	KRefTrace(p->name);
-	/* It is not necessary to trace p->age field,
-	 * because p->age is not an Object */
-#endif
-}
-
 //## Libevent Libevent.new();
 static KMETHOD Libevent_new(KonohaContext *kctx, KonohaStack *sfp)
 {
-	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
+	kLibevent *ev = (kLibevent *)sfp[0].asObject;
 	ev->event_base = event_base_new();
 	KReturn(ev);
 }
+
+/* ======================================================================== */
+//## int System.event_add(Libevent_event event, Date tv);
+KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
+{
+#define Declare_kDate
+#ifdef Declare_kDate	//TODO:It should be declared in headerfile in js4.date package.
+	typedef struct kDateVar {
+		kObjectHeader h;
+		struct timeval tv;
+	} kDate;
+#endif	//Declare_kDate
+#undef Declare_kDate
+
+	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;
+	kDate *date = (kDate *)sfp[2].asObject;
+	int ret = event_add(ev->event, &date->tv);
+	KReturnUnboxValue(ret);
+}
+
 static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int option, KTraceInfo *trace)
 {
 	/* Class Definition */
@@ -93,8 +83,6 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	SETSTRUCTNAME(defLibevent, Libevent);
 	defLibevent.cflag     = KClassFlag_Final;
 	defLibevent.init      = Libevent_Init;
-	defLibevent.p         = Libevent_p;
-	defLibevent.reftrace  = Libevent_Reftrace;
 	defLibevent.free      = Libevent_Free;
 	KClass *LibeventClass = KLIB kNameSpace_DefineClass(kctx, ns, NULL, &defLibevent, trace);
 
@@ -103,6 +91,10 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 
 	KDEFINE_METHOD MethodData[] = {
 		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"), 0,
+		_Public|_Static|_Const|_Im, _F(System_event_add), KType_int, KType_System, KKMethodName_("event_add"), 2, KType_Object, KFieldName_("Libevent_event"), KType_Object, KFieldName_("timeval"),	//TODO: param type should be "KType_Libevent_event" "KType_Date"
+
+
+
 #ifdef	CUTCUT
 		_Public, _F(Person_say), KType_String, KType_Person, KKMethodName_("say"), 0,
 #endif

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -1,0 +1,160 @@
+/****************************************************************************
+ * Copyright (c) 2012, the Konoha project authors. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************************************************************************/
+
+#include <minikonoha/minikonoha.h>
+#include <minikonoha/sugar.h>
+#include <minikonoha/import/methoddecl.h>
+#include <event2/event.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Libevent {
+	kObjectHeader h;
+	struct event_base/*?*/ *event_base;
+} kLibevent;
+
+static void Libevent_Init(KonohaContext *kctx, kObject *o, void *conf)
+{
+	struct Libevent *ev = (struct Libevent *) o;
+	ev->event_base = NULL/*?*/;	//refered jansson_glue.c
+}
+
+static void Libevent_Free(KonohaContext *kctx, kObject *o)
+{
+	struct Libevent *ev = (struct Libevent *) o;
+
+	if (ev->event_base != NULL) {
+		event_base_free(ev->event_base);
+		ev->event_base = NULL;
+	}
+}
+
+static void Libevent_p(KonohaContext *kctx, KonohaValue *v, int pos, KBuffer *wb)
+{
+#if 0	
+	/*
+	Is event_base able to serialize?
+	e.g. including FileDescriptor, kqueue...
+	*/
+
+	/* This function is called when serializing the object. */
+	struct Person *p = (struct Person *) v[pos].asObject;
+	KLIB KBuffer_Write(kctx, wb, kString_text(p->name), kString_size(p->name));
+	KLIB KBuffer_Write(kctx, wb, ",", 1);
+	KLIB KBuffer_printf(kctx, wb, KINT_FMT, p->age);
+#endif
+}
+
+static void Libevent_Reftrace(KonohaContext *kctx, kObject *o, KObjectVisitor *visitor)
+{
+#if 0
+	/* Garbage collector (GC) cannot recognize in which position of the field
+	 * an object exists. The function tells to GC which object should be traced. */
+	struct Person *p = (struct Person *) o;
+	/* If p->some_field is Nullable, please use 
+	 * KRefTraceNullable() macro instead of KRefTrace(). */
+	KRefTrace(p->name);
+	/* It is not necessary to trace p->age field,
+	 * because p->age is not an Object */
+#endif
+}
+
+//## Libevent Libevent.new();
+static KMETHOD Libevent_new(KonohaContext *kctx, KonohaStack *sfp)
+{
+	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
+	ev->event_base = event_base_new();
+	KReturn(ev);
+}
+static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int option, KTraceInfo *trace)
+{
+	/* Class Definition */
+	/* If you want to create Generic class like Array<T>, see konoha.map package */
+	KDEFINE_CLASS defLibevent = {0};
+	SETSTRUCTNAME(defLibevent, Libevent);
+	defLibevent.cflag     = KClassFlag_Final;
+	defLibevent.init      = Libevent_Init;
+	defLibevent.p         = Libevent_p;
+	defLibevent.reftrace  = Libevent_Reftrace;
+	defLibevent.free      = Libevent_Free;
+	KClass *LibeventClass = KLIB kNameSpace_DefineClass(kctx, ns, NULL, &defLibevent, trace);
+
+	/* You can define methods with the following procedures. */
+	int KType_Libevent = LibeventClass->typeId;
+
+	KDEFINE_METHOD MethodData[] = {
+		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"),
+#ifdef	CUTCUT
+		_Public, _F(Person_say), KType_String, KType_Person, KKMethodName_("say"), 0,
+#endif
+		DEND, /* <= sentinel */
+	};
+	KLIB kNameSpace_LoadMethodData(kctx, ns, MethodData, trace);
+
+	/* You can define constant variable with the following procedures. */
+	KDEFINE_INT_CONST IntData[] = {
+		{"NARUTO_AGE", KType_int, 18},
+		{} /* <= sentinel */
+	};
+	KLIB kNameSpace_LoadConstData(kctx, ns, KConst_(IntData), false/*isOverride*/, trace);
+	return true;
+}
+
+static kbool_t Libevent_ExportNameSpace(KonohaContext *kctx, kNameSpace *ns, kNameSpace *exportNS, int option, KTraceInfo *trace)
+{
+	return true;
+}
+
+KDEFINE_PACKAGE *libevent_Init(void)
+{
+	static KDEFINE_PACKAGE d = {0};
+	KSetPackageName(d, "Libevent2", "0.1");
+	d.PackupNameSpace    = Libevent_PackupNameSpace;
+	d.ExportNameSpace   = Libevent_ExportNameSpace;
+	return &d;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#if CUTCUT
+//## String Person.say();
+static KMETHOD Libevent_event_new(KonohaContext *kctx, KonohaStack *sfp)
+{
+	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
+
+	kString *name = p->name;
+	/* When you want to operate with a raw string, please use kString_text() macro
+	 * to acquire the pointer of a raw string. */
+	const char *text = kString_text(name);
+	char *buf = (char *)alloca(16 + kString_size(name));
+	sprintf(buf, "hello , %s!", text);
+	KReturn(KLIB new_kString(kctx, OnStack, buf, strlen(buf), StringPolicy_TEXT));
+}
+#endif

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012, the Konoha project authors. All rights reserved.
+ * Copyright (c) 2013, the Konoha project authors. All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
@@ -66,7 +66,7 @@ static KMETHOD Libevent_dispatch(KonohaContext *kctx, KonohaStack *sfp)
 
 /* ======================================================================== */
 //## int System.event_add(Libevent_event event, Date tv);
-//TODO: this declaration may be made in Libevent_event_glue.c
+//TODO: this declaration may be in Libevent_event_glue.c
 KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
 {
 	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;
@@ -76,7 +76,7 @@ KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
 }
 
 //## int System.event_del(Libevent_event event);
-//TODO: this declaration may be made in Libevent_event_glue.c
+//TODO: this declaration may be in Libevent_event_glue.c
 KMETHOD System_event_del(KonohaContext *kctx, KonohaStack* sfp)
 {
 	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -56,6 +56,14 @@ static KMETHOD Libevent_new(KonohaContext *kctx, KonohaStack *sfp)
 	KReturn(ev);
 }
 
+//## Libevent Libevent.dispatch();
+static KMETHOD Libevent_dispatch(KonohaContext *kctx, KonohaStack *sfp)
+{
+	kLibevent *ev = (kLibevent *)sfp[0].asObject;
+	int ret = event_base_dispatch(ev->event_base);
+	KReturnUnboxValue(ret);
+}
+
 /* ======================================================================== */
 //## int System.event_add(Libevent_event event, Date tv);
 //TODO: this declaration may be made in Libevent_event_glue.c
@@ -101,6 +109,7 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 
 	KDEFINE_METHOD MethodData[] = {
 		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"), 0,
+		_Public, _F(Libevent_dispatch), KType_Libevent, KType_Libevent, KKMethodName_("dispatch"), 0,
 		_Public|_Static|_Const|_Im, _F(System_event_add), KType_int, KType_System, KKMethodName_("event_add"), 2, KType_Object, KFieldName_("Libevent_event"), KType_Object, KFieldName_("timeval"),	//TODO: param type should be "KType_Libevent_event" "KType_Date"
 		_Public|_Static|_Const|_Im, _F(System_event_del), KType_int, KType_System, KKMethodName_("event_del"), 1, KType_Object, KFieldName_("Libevent_event"),	//TODO: param type should be "KType_Libevent_event"
 
@@ -113,14 +122,6 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	};
 	KLIB kNameSpace_LoadMethodData(kctx, ns, MethodData, trace);
 
-#ifdef	CUTCUT
-	/* You can define constant variable with the following procedures. */
-	KDEFINE_INT_CONST IntData[] = {
-		{"NARUTO_AGE", KType_int, 18},
-		{} /* <= sentinel */
-	};
-	KLIB kNameSpace_LoadConstData(kctx, ns, KConst_(IntData), false/*isOverride*/, trace);
-#endif
 	return true;
 }
 
@@ -139,23 +140,5 @@ KDEFINE_PACKAGE *libevent_Init(void)
 }
 
 #ifdef __cplusplus
-}
-#endif
-
-
-
-#if CUTCUT
-//## String Person.say();
-static KMETHOD Libevent_event_add(KonohaContext *kctx, KonohaStack *sfp)
-{
-	struct Libevent *ev = (struct Libevent *) sfp[0].asObject;
-
-	kString *name = p->name;
-	/* When you want to operate with a raw string, please use kString_text() macro
-	 * to acquire the pointer of a raw string. */
-	const char *text = kString_text(name);
-	char *buf = (char *)alloca(16 + kString_size(name));
-	sprintf(buf, "hello , %s!", text);
-	KReturn(KLIB new_kString(kctx, OnStack, buf, strlen(buf), StringPolicy_TEXT));
 }
 #endif

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -58,6 +58,7 @@ static KMETHOD Libevent_new(KonohaContext *kctx, KonohaStack *sfp)
 
 /* ======================================================================== */
 //## int System.event_add(Libevent_event event, Date tv);
+//TODO: this declaration may be made in Libevent_event_glue.c
 KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
 {
 #define Declare_kDate
@@ -72,6 +73,15 @@ KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
 	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;
 	kDate *date = (kDate *)sfp[2].asObject;
 	int ret = event_add(ev->event, &date->tv);
+	KReturnUnboxValue(ret);
+}
+
+//## int System.event_del(Libevent_event event);
+//TODO: this declaration may be made in Libevent_event_glue.c
+KMETHOD System_event_del(KonohaContext *kctx, KonohaStack* sfp)
+{
+	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;
+	int ret = event_del(ev->event);
 	KReturnUnboxValue(ret);
 }
 
@@ -92,6 +102,7 @@ static kbool_t Libevent_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int
 	KDEFINE_METHOD MethodData[] = {
 		_Public, _F(Libevent_new), KType_Libevent, KType_Libevent, KKMethodName_("new"), 0,
 		_Public|_Static|_Const|_Im, _F(System_event_add), KType_int, KType_System, KKMethodName_("event_add"), 2, KType_Object, KFieldName_("Libevent_event"), KType_Object, KFieldName_("timeval"),	//TODO: param type should be "KType_Libevent_event" "KType_Date"
+		_Public|_Static|_Const|_Im, _F(System_event_del), KType_int, KType_System, KKMethodName_("event_del"), 1, KType_Object, KFieldName_("Libevent_event"),	//TODO: param type should be "KType_Libevent_event"
 
 
 

--- a/src/package-devel/libevent/libevent_glue.c
+++ b/src/package-devel/libevent/libevent_glue.c
@@ -69,15 +69,6 @@ static KMETHOD Libevent_dispatch(KonohaContext *kctx, KonohaStack *sfp)
 //TODO: this declaration may be made in Libevent_event_glue.c
 KMETHOD System_event_add(KonohaContext *kctx, KonohaStack* sfp)
 {
-#define Declare_kDate
-#ifdef Declare_kDate	//TODO:It should be declared in headerfile in js4.date package.
-	typedef struct kDateVar {
-		kObjectHeader h;
-		struct timeval tv;
-	} kDate;
-#endif	//Declare_kDate
-#undef Declare_kDate
-
 	kLibevent_event *ev = (kLibevent_event *)sfp[1].asObject;
 	kDate *date = (kDate *)sfp[2].asObject;
 	int ret = event_add(ev->event, &date->tv);

--- a/src/package-devel/libevent/libevent_glue.h
+++ b/src/package-devel/libevent/libevent_glue.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012, the Konoha project authors. All rights reserved.
+ * Copyright (c) 2013, the Konoha project authors. All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/src/package-devel/libevent/libevent_glue.h
+++ b/src/package-devel/libevent/libevent_glue.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ * Copyright (c) 2012, the Konoha project authors. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************************************************************************/
+
+typedef struct Libevent {
+	kObjectHeader h;
+	struct event_base *event_base;
+} kLibevent;
+
+typedef struct Libevent_event {
+	kObjectHeader h;
+	struct event *event;
+} kLibevent_event;

--- a/src/package-devel/libevent/libevent_glue.h
+++ b/src/package-devel/libevent/libevent_glue.h
@@ -31,3 +31,12 @@ typedef struct Libevent_event {
 	kObjectHeader h;
 	struct event *event;
 } kLibevent_event;
+
+#define Declare_kDate
+#ifdef Declare_kDate	//TODO:It should be declared in headerfile in js4.date package.
+	typedef struct kDateVar {
+		kObjectHeader h;
+		struct timeval tv;
+	} kDate;
+#endif	//Declare_kDate
+#undef Declare_kDate

--- a/src/package-devel/libevent/libevent_glue.k
+++ b/src/package-devel/libevent/libevent_glue.k
@@ -1,3 +1,27 @@
+/****************************************************************************
+ * Copyright (c) 2013, the Konoha project authors. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************************************************************************/
+
 import("konoha.new");
 import("konoha.class");
 import("konoha.object");

--- a/src/package-devel/libevent/libevent_glue.k
+++ b/src/package-devel/libevent/libevent_glue.k
@@ -2,7 +2,21 @@ import("konoha.new");
 import("konoha.class");
 import("konoha.object");
 import("konoha.map");
+import("cstyle");
+import("js4.date");
 
-class test {
-	Map hoge = Map[Object];
+class Libevent {
+	Map event_Map;
+
+	Libevent(void) {
+		event_Map =  = new Map();
+	}
+
+	int event_add(String key, Date tv) {
+		if (key.isNull()) {
+			event_Map.set(key, new event());
+		}
+		Libevent_event ev = event_Map.get(key);
+		return this.event_add(ev, tv);
+	}
 }

--- a/src/package-devel/libevent/libevent_glue.k
+++ b/src/package-devel/libevent/libevent_glue.k
@@ -1,0 +1,8 @@
+import("konoha.new");
+import("konoha.class");
+import("konoha.object");
+import("konoha.map");
+
+class test {
+	Map hoge = Map[Object];
+}

--- a/src/package-devel/libevent/libevent_glue.k
+++ b/src/package-devel/libevent/libevent_glue.k
@@ -8,15 +8,15 @@ import("js4.date");
 class Libevent {
 	Map event_Map;
 
-	Libevent(void) {
+	Libevent() {
 		event_Map =  = new Map();
 	}
 
 	int event_add(String key, Date tv) {
 		if (key.isNull()) {
-			event_Map.set(key, new event());
+			this.event_Map.set(key, new event());
 		}
 		Libevent_event ev = event_Map.get(key);
-		return this.event_add(ev, tv);
+		return System.event_add(ev, tv);
 	}
 }

--- a/src/package-devel/libevent/sample/mytest.k
+++ b/src/package-devel/libevent/sample/mytest.k
@@ -1,0 +1,20 @@
+import("konoha.map");
+import("konoha.new");
+import("konoha.class");
+import("konoha.object");
+//import("konoha.global");
+
+class event {
+	Map a;
+	
+	event(void) {
+		a = new Map();
+	}
+
+	void main(void) {
+		a.set("test", new Object());
+		System.p("a.get(\"test\") = " + a.get("test"));
+	}
+}
+
+new event().main();


### PR DESCRIPTION
Libevent の典型的関数について、パッケージ化してみました。
# まだ、ほんの一部のみです。

ひとまず、 pull request  という形で出していますが、まだまだ、マージするようなレベルではないと思っています。

いくつか説明をしておきます。
1. libevent クラス(libevent_glue.[ck]) と libevent_eventクラス(libevent_event_glue.[ck]) を定義しています。
    構造体についてはオブジェクトとして定義するものと考えてこのようにしましたが合っていますか？
    また、可能ならば、クラス毎にソースファイルを分割したほうが良いと思い分けました。これにより、konoha オブジェクト構造体を相互に参照するために、ヘッダファイルとしてまとめてあります。
2. posix の "struct timeval" が js4.date パッケージの kDate として定義されていたのですが、参照する手段がわからなかったため、 libevent_glue.h 内にて ifdef で囲って再定義しています。
    他パッケージのオブジェクト構造体定義を foo_glue.c において参照する手段はあるのでしょうか？
    posix 関連のオブジェクト構造体は、様々はパッケージで参照したいように思います。
3. libevent_glue.c において Libevent クラスを定義して、 さらに libevent_glue.k において Libevent クラスのインスタンス、メソッドを追加定義したいのですが、エラーが出ています。

----- konoha script -----
     1  import("konoha.new");
     2  import("konoha.class");
     3  import("konoha.object");
     4  import("libevent");
     5
     6  void main() {
     7  //      Libevent_k e = new Libevent_k();
     8          Libevent e = new Libevent();
     9
    10          e.event_add("listener", K_NULL);
    11
    12
    13
    14  }
    15
    16  main();
----- konoha script end -----
- (error) (libevent_glue.k:8) Libevent has already defined
- (error) (event-test.k:10) undefined method: Libevent.event_add
  RuntimeScriptException: SoftwareFault (error) (event-test.k:10) undefined method: Libevent.event_add
  StackTrace
  [8](event-test.k:10) NameSpace.main(this=(NameSpace) main, )

原因がわかるようでしたらご教示いただけると助かります。
4. まだ悩んでいるものについては、コメントに "TODO" としてマークしてあります。

以上
