### PR TITLE
add NameSpace.AddSyntaxPattern() method

### DIFF
--- a/include/minikonoha/sugar.h
+++ b/include/minikonoha/sugar.h
@@ -606,7 +606,7 @@ typedef struct {
 	//
 	kSyntax*      (*kNameSpace_GetSyntax)(KonohaContext *, kNameSpace *, ksymbol_t);
 	void          (*kNameSpace_DefineSyntax)(KonohaContext *, kNameSpace *, KDEFINE_SYNTAX *, KTraceInfo *);
-	void          (*kNameSpace_AddSyntaxPattern)(KonohaContext *, kNameSpace *, ksymbol_t, const char *rule, kfileline_t uline, KTraceInfo *);
+	void          (*kNameSpace_AddSyntaxPattern)(KonohaContext *, kSyntax *, const char *rule, kfileline_t uline, KTraceInfo *);
 	void          (*kNameSpace_AddSyntax)(KonohaContext *, kNameSpace *, kSyntax *, KTraceInfo *);
 //	kSyntaxVar*   (*kNameSpace_SetTokenFunc)(KonohaContext *, kNameSpace *, ksymbol_t, int ch, kFunc *);
 //	kSyntaxVar*   (*kNameSpace_AddSugarFunc)(KonohaContext *, kNameSpace *, ksymbol_t kw, size_t idx, kFunc *);
@@ -647,7 +647,7 @@ typedef struct {
 
 	kNode*       (*new_MethodNode)(KonohaContext *, kNameSpace *, KClass *, kMethod *mtd, int n, ...);
 
-	kNode*      (*TypeCheckBlock)(KonohaContext *, kNode *, kNameSpace *, KClass *);
+//	kNode*      (*TypeCheckBlock)(KonohaContext *, kNode *, kNameSpace *, KClass *);
 	kNode*      (*TypeCheckNodeByName)(KonohaContext *, kNode*, ksymbol_t, kNameSpace *, KClass *, int);
 	kNode*      (*TypeCheckNodeAt)(KonohaContext *, kNode *, size_t, kNameSpace *, KClass *, int);
 	kNode *     (*TypeCheckMethodParam)(KonohaContext *, kMethod *mtd, kNode *, kNameSpace *, KClass *);

--- a/src/package-devel/MiniKonoha.NameSpace/NameSpace_glue.c
+++ b/src/package-devel/MiniKonoha.NameSpace/NameSpace_glue.c
@@ -207,14 +207,14 @@ static KMETHOD TypeCheck_Defined(KonohaContext *kctx, KonohaStack *sfp)
 static kbool_t namespace_defineSyntax(KonohaContext *kctx, kNameSpace *ns, KTraceInfo *trace)
 {
 	KDEFINE_SYNTAX SYNTAX[] = {
-		{ KSymbol_("namespace"), SYNFLAG_CTypeFunc, 0, Precedence_Statement, {NULL}, {SUGARFUNC Statement_namespace}},
-		{ KSymbol_("const"), SYNFLAG_CTypeFunc, 0, Precedence_Statement, {NULL}, {SUGARFUNC Statement_ConstDecl}},
+		{ KSymbol_("namespace"), SYNFLAG_CTypeFunc, 0, Precedence_Statement, {SUGAR patternParseFunc}, {SUGARFUNC Statement_namespace}},
+		{ KSymbol_("const"), SYNFLAG_CTypeFunc, 0, Precedence_Statement, {SUGAR patternParseFunc}, {SUGARFUNC Statement_ConstDecl}},
 		{ KSymbol_("defined"), SYNFLAG_CFunc,0, Precedence_CStylePrefixOperator, {SUGARFUNC Expression_Defined}, {SUGARFUNC TypeCheck_Defined},},
 		{ KSymbol_END, },
 	};
 	SUGAR kNameSpace_DefineSyntax(kctx, ns, SYNTAX, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("namespace"), "\"namespace\" $Expr", 0, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("const"), "\"const\" $Symbol \"=\" $Expr", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("namespace")), "\"namespace\" $Expr", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("const")), "\"const\" $Symbol \"=\" $Expr", 0, trace);
 	return true;
 }
 

--- a/src/package-devel/Syntax.JavaStyleClass/JavaStyleClass_glue.c
+++ b/src/package-devel/Syntax.JavaStyleClass/JavaStyleClass_glue.c
@@ -420,7 +420,7 @@ static kbool_t class_defineSyntax(KonohaContext *kctx, kNameSpace *ns, KTraceInf
 		{ KSymbol_END, },
 	};
 	SUGAR kNameSpace_DefineSyntax(kctx, ns, SYNTAX, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("class"), "\"class\" $ClassName [\"extends\" extends: $Type] [$Block]", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("class")), "\"class\" $ClassName [\"extends\" extends: $Type] [$Block]", 0, trace);
 	return true;
 }
 

--- a/src/package/Syntax.CStyleFor/CStyleFor_glue.c
+++ b/src/package/Syntax.CStyleFor/CStyleFor_glue.c
@@ -91,7 +91,7 @@ static kbool_t cstyle_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int o
 		{ KSymbol_END, }, /* sentinental */
 	};
 	SUGAR kNameSpace_DefineSyntax(kctx, ns, SYNTAX, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("for"), "\"for\" \"(\" init: $ForStmt \";\" $Expr \";\" Iterator: $ForStmt \")\" $Block", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("for")), "\"for\" \"(\" init: $ForStmt \";\" $Expr \";\" Iterator: $ForStmt \")\" $Block", 0, trace);
 	return true;
 }
 

--- a/src/package/Syntax.CStyleWhile/CStyleWhile_glue.c
+++ b/src/package/Syntax.CStyleWhile/CStyleWhile_glue.c
@@ -102,10 +102,10 @@ static kbool_t cstyle_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int o
 		{ KSymbol_END, }, /* sentinental */
 	};
 	SUGAR kNameSpace_DefineSyntax(kctx, ns, SYNTAX, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("while"), "\"while\" \"(\" $Expr \")\" $Block", 0, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("do"), "\"do\" $Block \"while\" \"(\" $Expr \")\"", 0, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("break"), "\"break\"", 0, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("continue"), "\"continue\"", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("while")), "\"while\" \"(\" $Expr \")\" $Block", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("do")), "\"do\" $Block \"while\" \"(\" $Expr \")\"", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("break")), "\"break\"", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("continue")), "\"continue\"", 0, trace);
 	return true;
 }
 

--- a/src/package/Syntax.Increment/Increment_glue.c
+++ b/src/package/Syntax.Increment/Increment_glue.c
@@ -201,7 +201,7 @@ static kbool_t cstyle_PackupNameSpace(KonohaContext *kctx, kNameSpace *ns, int o
 		{ KSymbol_END, }, /* sentinental */
 	};
 	SUGAR kNameSpace_DefineSyntax(kctx, ns, SYNTAX, trace);
-	SUGAR kNameSpace_AddSyntaxPattern(kctx, ns, KSymbol_("$Inc"), "$IncStmt", 0, trace);
+	SUGAR kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, KSymbol_("$Inc")), "$IncStmt", 0, trace);
 	SUGAR SetMacroData(kctx, ns, KSymbol_("++"), 1,  "X X = (X) + 1", false);
 	SUGAR SetMacroData(kctx, ns, KSymbol_("--"), 1,  "X X = (X) - 1", false);
 

--- a/src/parser/import/pattern.h
+++ b/src/parser/import/pattern.h
@@ -265,10 +265,9 @@ static void PreprocessSyntaxPattern2(KonohaContext *kctx, kTokenVar *tk, kTokenV
 	}
 }
 
-static void kNameSpace_AddSyntaxPattern(KonohaContext *kctx, kNameSpace *ns, ksymbol_t keyword, const char *ruleSource, kfileline_t uline, KTraceInfo *trace)
+static void kNameSpace_AddSyntaxPattern(KonohaContext *kctx, kSyntaxVar *syntax, const char *ruleSource, kfileline_t uline, KTraceInfo *trace)
 {
-	kSyntaxVar *syntax = (kSyntaxVar*)kNameSpace_GetSyntax(kctx, ns, keyword);
-	DBG_ASSERT(IS_NOTNULL(syntax));
+	kNameSpace *ns = syntax->packageNameSpace;
 	if(syntax->syntaxPatternListNULL == NULL) {
 		syntax->syntaxPatternListNULL = new_(TokenArray, 0, ns->NameSpaceConstList);
 	}

--- a/src/parser/import/syntax.h
+++ b/src/parser/import/syntax.h
@@ -1391,10 +1391,10 @@ static void DefineDefaultSyntax(KonohaContext *kctx, kNameSpace *ns)
 	KPARSERM->patternParseFunc  = patternParseFunc;
 	KPARSERM->methodTypeFunc = MethodCallFunc;
 	// Syntax Rule
-	kNameSpace_AddSyntaxPattern(kctx, ns, PATTERN(TypeDecl), "$Type $Expr", 0, NULL);
-	kNameSpace_AddSyntaxPattern(kctx, ns, PATTERN(MethodDecl), "$Type [ClassName: $Type] [$Symbol] $Param [$Block]", 0, NULL);
-	kNameSpace_AddSyntaxPattern(kctx, ns, TOKEN(if), "\"if\" \"(\" $Expr \")\" $Block [\"else\" else: $Block]", 0, NULL);
-	kNameSpace_AddSyntaxPattern(kctx, ns, TOKEN(else), "\"else\" $Block", 0, NULL);
-	kNameSpace_AddSyntaxPattern(kctx, ns, TOKEN(return), "\"return\" [$Expr]", 0, NULL);
+	kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, PATTERN(TypeDecl)), "$Type $Expr", 0, NULL);
+	kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, PATTERN(MethodDecl)), "$Type [ClassName: $Type] [$Symbol] $Param [$Block]", 0, NULL);
+	kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, TOKEN(if)), "\"if\" \"(\" $Expr \")\" $Block [\"else\" else: $Block]", 0, NULL);
+	kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, TOKEN(else)), "\"else\" $Block", 0, NULL);
+	kNameSpace_AddSyntaxPattern(kctx, kSyntax_(ns, TOKEN(return)), "\"return\" [$Expr]", 0, NULL);
 }
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -198,7 +198,7 @@ void MODSUGAR_Init(KonohaContext *kctx, KonohaContextVar *ctx)
 	mod->kNode_SetVariable          = kNode_SetVariable;
 	mod->TypeCheckNodeAt        = TypeCheckNodeAt;
 	mod->TypeCheckNodeByName        = TypeCheckNodeByName;
-	mod->TypeCheckBlock               = TypeCheckBlock;
+//	mod->TypeCheckBlock               = TypeCheckBlock;
 	mod->TypeCheckMethodParam         = TypeCheckMethodParam;
 	mod->new_MethodNode               = new_MethodNode;
 	mod->AddLocalVariable  = AddLocalVariable;


### PR DESCRIPTION
modify kNameSpace_AddSyntaxPattern interface to use kSyntax \* instead of ksymbol_t and kNameSpace
add Syntax.SetPattern() method
add Syntax.SetMetaPattern() method
add Syntax.IsMetaPattern() method
