### PR TITLE
fix RubyStyle

### DIFF
--- a/src/package-devel/Syntax.RubyStyle/RubyStyle_glue.k
+++ b/src/package-devel/Syntax.RubyStyle/RubyStyle_glue.k
@@ -38,7 +38,7 @@ Node createBlockNode(NameSpace ns){
 
 Node Node.createBlockNodeAt(Symbol symbol){
 	Node blockNode = createBlockNode(this.getNameSpace());
-	this.setNode(symbol, blockNode);
+	this.AddParsedObject(symbol, blockNode);
 	return blockNode;
 }
 


### PR DESCRIPTION
fixed RubyStyle package because some MiniKonoha.Syntax api was renamed.
