### PR TITLE
fix a string bug that occurs when using both dshell and Json module

### DIFF
--- a/src/module/Json/kjson/kjson.h
+++ b/src/module/Json/kjson/kjson.h
@@ -336,7 +336,8 @@ static inline JSON JSONString_new(JSONMemoryPool *jm, const char *s, size_t len)
     JSONString *o = (JSONString *) JSONMemoryPool_Alloc(jm, sizeof(*o), &malloced);
     JSON json = toJSON(ValueS(o));
     JSON_Init(json);
-    char *str = (len > JSONSTRING_INLINE_SIZE) ? (char *) malloc(len) : o->text;
+    char *str = (len > JSONSTRING_INLINE_SIZE) ? (char *) malloc(len + 1) : o->text;
+    str[len] = '\0';
     memcpy(str, s, len);
     JSONString_init(o, (const char *)str, len);
     return json;


### PR DESCRIPTION
Fix a string bug that occurs when using both a large script (such as Syntax.ShellStyle package) and Json module.
If over 16 bytes of string is passed to json value, it becomes incorrect string.
## input

```
Import("Syntax.ShellStyle");
Import("Type.Json");

void test() {
    Json j = new Json();
    j.setString("16bytes", "0123456789012345");
    System.p(j.getString("16bytes"));
    j.setString("17bytes", "01234567890123456");
    System.p(j.getString("17bytes"));
}

test();
```
## output

```
 - (json.k:7) 0123456789012345
 - (json.k:9) 01234567890123456r/sbin:/sbin
```
