### PR TITLE
Fix JavaStyleClass

### DIFF
--- a/src/package/Syntax.JavaStyleClass/JavaStyleClass_glue.c
+++ b/src/package/Syntax.JavaStyleClass/JavaStyleClass_glue.c
@@ -356,17 +356,16 @@ static KMETHOD Statement_class(KonohaContext *kctx, KonohaStack *sfp)
 {
 	VAR_TypeCheck(stmt, ns, reqc);
 	kToken *tokenClassName = SUGAR kNode_GetToken(kctx, stmt, KSymbol_("$ClassName"), NULL);
-	int isNewlyDefinedClass = false;
 	KClassVar *definedClass = (KClassVar *)KLIB kNameSpace_GetClassByFullName(kctx, ns, kString_text(tokenClassName->text), kString_size(tokenClassName->text), NULL);
-	if(definedClass == NULL) {   // Already defined
+	const int isNewlyDefinedClass = (definedClass == NULL); 
+	if(isNewlyDefinedClass) {
 		kshortflag_t cflag = kNode_ParseClassFlag(kctx, stmt, KClassFlag_Virtual);
 		KMakeTraceUL(trace, sfp, kNode_uline(stmt));
 		definedClass = kNameSpace_DefineClassName(kctx, ns, cflag, tokenClassName->text, trace);
-		isNewlyDefinedClass = true;
 	}
 	kNode *block = kNode_ParseClassNodeNULL(kctx, stmt, tokenClassName);
 	size_t declsize = kNode_countFieldSize(kctx, block);
-	if(isNewlyDefinedClass) {   // Already defined
+	if(isNewlyDefinedClass || (KClass_Is(Virtual, definedClass) && block != NULL)) {  
 		KClass *superClass = KClass_Object;
 		kToken *tokenSuperClass= SUGAR kNode_GetToken(kctx, stmt, KSymbol_("extends"), NULL);
 		if(tokenSuperClass != NULL) {
@@ -382,7 +381,7 @@ static KMETHOD Statement_class(KonohaContext *kctx, KonohaStack *sfp)
 		size_t initsize = (block != NULL) ? declsize : initFieldSizeOfVirtualClass(superClass);
 		KClass_InitField(kctx, definedClass, superClass, initsize);
 	}
-	else {
+	else { // Already defined
 		if(declsize > 0 && !KClass_Is(Virtual, definedClass)) {
 			KReturn(SUGAR MessageNode(kctx, stmt, NULL, ns, ErrTag, "%s has already defined", KClass_text(definedClass)));
 		}

--- a/src/package/Syntax.JavaStyleClass/test/Experimental/ClassExtend_VirtualClass.k
+++ b/src/package/Syntax.JavaStyleClass/test/Experimental/ClassExtend_VirtualClass.k
@@ -1,4 +1,3 @@
-import("Syntax.Null")
 import("Syntax.JavaStyleClass")
 
 class Derived;

--- a/src/package/Syntax.JavaStyleClass/test/Experimental/ClassExtend_VirtualClass.k
+++ b/src/package/Syntax.JavaStyleClass/test/Experimental/ClassExtend_VirtualClass.k
@@ -1,0 +1,19 @@
+import("Syntax.Null")
+import("Syntax.JavaStyleClass")
+
+class Derived;
+class Base{
+	@Public int a;
+	@Public Derived d;
+}
+class Derived extends Base{
+	@Public Derived(){}
+}
+
+
+void main(){
+	Base b = new Derived();
+	assert(b.a == 0);
+}
+main();
+


### PR DESCRIPTION
Fix JavaStyleClass.
forrowing code works correctly.

```
import("Syntax.JavaStyleClass")

class Derived;
class Base{
  Derived d;
}

class Derived extends Base{
  @Public Derived(){}
}

void main(){
  Base b = new Derived();
}

```
