### PR TITLE
fix mistake of d2a9387

### DIFF
--- a/include/konoha3/arch/minivm.h
+++ b/include/konoha3/arch/minivm.h
@@ -194,7 +194,7 @@ typedef struct OPNMOVx {
 #ifndef OPEXEC_NMOVx
 #define OPEXEC_NMOVx() do {\
 	OPNMOVx *op = (OPNMOVx *)pc;\
-	rbp[op->src].unboxValue = (rbp[op->dst].asObject)->fieldUnboxItems[op->bx];\
+	rbp[op->dst].unboxValue = (rbp[op->src].asObject)->fieldUnboxItems[op->bx];\
 } while(0)
 #endif
 


### PR DESCRIPTION
At d2a9387, definition of `op->{a,b}` is renamed to `op->{dst,src}`.
However there is a mistake of replacement of them.
