### PR TITLE
fix string replace bug

### DIFF
--- a/src/package/Common.StringUtil/string_api.h
+++ b/src/package/Common.StringUtil/string_api.h
@@ -256,7 +256,7 @@ static kString* String_replaceFirst(KonohaContext *kctx, kString *self, kString 
 	const char *end  = text + kString_size(self);
 	const char *pos  = strstr(text, kString_text(oldText));
 	const size_t oldLen = kString_size(oldText);
-	if(pos == NULL)
+	if(pos == NULL || oldLen == 0)
 		return self;
 	KBuffer wb;
 	KLIB KBuffer_Init(&(kctx->stack->cwb), &wb);
@@ -271,7 +271,7 @@ static kString* String_replace(KonohaContext *kctx, kString *self, const char *o
 	const char *text = kString_text(self);
 	const char *end  = text + kString_size(self);
 	const char *pos  = strstr(text, oldText);
-	if(pos == NULL)
+	if(pos == NULL || oldLen == 0)
 		return self;
 	KBuffer wb;
 	KLIB KBuffer_Init(&(kctx->stack->cwb), &wb);


### PR DESCRIPTION
fix string replace bug that forrowing code cause infinity loop.

```
"".replace("", "")
```
