### PR TITLE
Add KStackSetObjectValue, KStackSetUnboxValue

### DIFF
--- a/include/konoha3/arch/minivm.h
+++ b/include/konoha3/arch/minivm.h
@@ -310,11 +310,11 @@ typedef struct OPCALL {
 	OPCALL *op = (OPCALL *)pc;\
 	kMethod *mtd_ = rbp[op->thisidx + K_MTDIDX2].calledMethod;\
 	KonohaStack *sfp_ = (KonohaStack *)(rbp + op->thisidx); \
-	KUnsafeFieldSet(sfp_[K_RTNIDX].asObject, op->tyo);\
-	sfp_[K_RTNIDX].calledFileLine = op->uline;\
-	sfp_[K_SHIFTIDX].previousStack = (KonohaStack *)(rbp);\
-	sfp_[K_PCIDX].pc = PC_NEXT(pc);\
-	sfp_[K_MTDIDX].calledMethod = mtd_;\
+	KStackSetObjectValue(sfp_[K_RTNIDX].asObject, op->tyo);\
+	KStackSetUnboxValue(sfp_[K_RTNIDX].calledFileLine, op->uline);\
+	KStackSetUnboxValue(sfp_[K_SHIFTIDX].previousStack, (KonohaStack *)(rbp));\
+	KStackSetUnboxValue(sfp_[K_PCIDX].pc, PC_NEXT(pc));\
+	KStackSetUnboxValue(sfp_[K_MTDIDX].calledMethod, mtd_);\
 	((KonohaContextVar *)kctx)->esp = (KonohaStack *)(rbp + op->espshift);\
 	(mtd_)->invokeKMethodFunc(kctx, sfp_); \
 } while(0)

--- a/include/konoha3/konoha.h
+++ b/include/konoha3/konoha.h
@@ -1631,23 +1631,23 @@ struct kSystemVar {
 #define BEGIN_UnusedStack(SFP) KonohaStack *SFP = kctx->esp + K_CALLDELTA, *esp_ = kctx->esp; KStackCheckOverflow(kctx->stack->topStack);
 #define END_UnusedStack()      ((KonohaContextVar *)kctx)->esp = esp_;
 
-#define KStackSetLine(SFP, UL)    SFP[K_RTNIDX].calledFileLine   = UL
+#define KStackSetLine(SFP, UL)    KStackSetUnboxValue(SFP[K_RTNIDX].calledFileLine, UL)
 #define KStackSetArgc(SFP, ARGC)  ((KonohaContextVar *)kctx)->esp = (SFP + ARGC + 1)
 
 #define KStackSetMethodAll(SFP, DEFVAL, UL, MTD, ARGC) { \
-		KUnsafeFieldSet(SFP[K_RTNIDX].asObject, ((kObject *)DEFVAL));\
+		KStackSetObjectValue(SFP[K_RTNIDX].asObject, ((kObject *)DEFVAL));\
 		KStackSetLine(SFP, UL);\
 		KStackSetArgc(SFP, ARGC);\
-		SFP[K_MTDIDX].calledMethod = MTD; \
+		KStackSetUnboxValue(SFP[K_MTDIDX].calledMethod, MTD); \
 	} \
 
 
 #define KStackSetFunc(SFP, FO) do {\
-	SFP[K_MTDIDX].calledMethod = (FO)->method;\
+	KStackSetUnboxValue(SFP[K_MTDIDX].calledMethod, (FO)->method);\
 }while(0);\
 
 #define KStackSetFuncAll(SFP, DEFVAL, UL, FO, ARGC) { \
-		KUnsafeFieldSet(SFP[K_RTNIDX].asObject, ((kObject *)DEFVAL));\
+		KStackSetObjectValue(SFP[K_RTNIDX].asObject, ((kObject *)DEFVAL));\
 		KStackSetLine(SFP, UL);\
 		KStackSetArgc(SFP, ARGC);\
 		KStackSetFunc(SFP, FO);\
@@ -1655,14 +1655,14 @@ struct kSystemVar {
 
 // if you want to ignore (exception), use KRuntime_tryCallMethod
 #define KStackCall(SFP) { \
-		SFP[K_SHIFTIDX].previousStack = kctx->stack->topStack;\
+		KStackSetUnboxValue(SFP[K_SHIFTIDX].previousStack, kctx->stack->topStack);\
 		kctx->stack->topStack = SFP;\
 		(SFP[K_MTDIDX].calledMethod)->invokeKMethodFunc(kctx, SFP);\
 		kctx->stack->topStack = SFP[K_SHIFTIDX].previousStack;\
 	} \
 
 #define KStackCallAgain(SFP, MTD) { \
-		SFP[K_MTDIDX].calledMethod = MTD;\
+		KStackSetUnboxValue(SFP[K_MTDIDX].calledMethod, MTD);\
 		(MTD)->invokeKMethodFunc(kctx, SFP);\
 	} \
 
@@ -1958,7 +1958,9 @@ typedef struct {
 
 #define KUnsafeFieldInit(VAR, VAL) OBJECT_SET(VAR, VAL)
 #define KUnsafeFieldSet( VAR, VAL) (VAR) = (VAL) /* for c-compiler type check */
-#define KStackSet(VAR, VAL)  (VAR) = (VAL)
+
+#define KStackSetObjectValue(VAR, VAL)  KUnsafeFieldSet(VAR, VAL)
+#define KStackSetUnboxValue(VAR, VAL)   (VAR) = (VAL)
 
 #define KFieldInit(PARENT, VAR, VAL) GC_WRITE_BARRIER(kctx, PARENT, VAR, VAL); KUnsafeFieldInit(VAR, VAL)
 #define KFieldSet(PARENT, VAR, VAL)  GC_WRITE_BARRIER(kctx, PARENT, VAR, VAL); KUnsafeFieldSet( VAR, VAL)
@@ -1998,40 +2000,40 @@ typedef struct {
 #define KGetLexicalNameSpace(sfp)    sfp[K_NSIDX].asNameSpace
 
 #define KReturnWith(VAL, CLEANUP) do {\
-	KUnsafeFieldSet(sfp[K_RTNIDX].asObject, ((kObject *)VAL));\
+	KStackSetObjectValue(sfp[K_RTNIDX].asObject, ((kObject *)VAL));\
 	CLEANUP;\
 	KCheckSafePoint(kctx, sfp);\
 	return; \
 } while(0)
 
 #define KReturnDefaultValue() do {\
-	sfp[K_RTNIDX].intValue = 0;\
+	KStackSetUnboxValue(sfp[K_RTNIDX].intValue, 0);\
 	return; \
 } while(0)
 
 #define KReturnField(vv) do {\
-	KUnsafeFieldSet(sfp[(-(K_CALLDELTA))].asObject, ((kObject *)vv));\
+	KStackSetObjectValue(sfp[(-(K_CALLDELTA))].asObject, ((kObject *)vv));\
 	return; \
 } while(0)
 
 #define KReturn(vv) do {\
-	KUnsafeFieldSet(sfp[(-(K_CALLDELTA))].asObject, ((kObject *)vv));\
+	KStackSetObjectValue(sfp[(-(K_CALLDELTA))].asObject, ((kObject *)vv));\
 	KCheckSafePoint(kctx, sfp);\
 	return; \
 } while(0)
 
 #define KReturnInt(d) do {\
-	sfp[K_RTNIDX].intValue = d; \
+	KStackSetUnboxValue(sfp[K_RTNIDX].intValue, d); \
 	return; \
 } while(0)
 
 #define KReturnUnboxValue(d) do {\
-	sfp[K_RTNIDX].unboxValue = d; \
+	KStackSetUnboxValue(sfp[K_RTNIDX].unboxValue, d); \
 	return; \
 } while(0)
 
 #define KReturnFloatValue(c) do {\
-	sfp[(-(K_CALLDELTA))].floatValue = c; \
+	KStackSetUnboxValue(sfp[(-(K_CALLDELTA))].floatValue, c); \
 	return; \
 } while(0)
 

--- a/src/exec/apache/mod_konoha.c
+++ b/src/exec/apache/mod_konoha.c
@@ -295,8 +295,8 @@ static int konoha_handler(request_rec *r)
 	/* XXX: We assume Request Object may not be freed by GC */
 	kObject *req_obj = KLIB new_kObject(kctx, OnStack, cRequest, (uintptr_t)r);
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[K_CALLDELTA+0].asObject, K_NULL);
-	KUnsafeFieldSet(lsfp[K_CALLDELTA+1].asObject, req_obj);
+	KStackSetObjectValue(lsfp[K_CALLDELTA+0].asObject, K_NULL);
+	KStackSetObjectValue(lsfp[K_CALLDELTA+1].asObject, req_obj);
 	{
 		KonohaStack *sfp = lsfp + K_CALLDELTA;
 		KStackSetMethodAll(sfp, KLIB Knull(kctx, KClass_Int), 0/*UL*/, mtd, 1);

--- a/src/konoha/import/datatype.h
+++ b/src/konoha/import/datatype.h
@@ -91,10 +91,10 @@ static void kObject_WriteToBuffer(KonohaContext *kctx, kObject *o, int isDelim, 
 			}
 		}
 		if(KType_Is(UnboxType, kObject_typeId(o))) {
-			sfp[pos].unboxValue = kObject_Unbox(o);
+			KStackSetUnboxValue(sfp[pos].unboxValue, kObject_Unbox(o));
 		}
 		else {
-			KUnsafeFieldSet(sfp[pos].asObject, o);
+			KStackSetObjectValue(sfp[pos].asObject, o);
 		}
 		kObject_class(o)->format(kctx, sfp, pos, wb);
 	}

--- a/src/konoha/import/klibexec.h
+++ b/src/konoha/import/klibexec.h
@@ -709,7 +709,7 @@ static void DumpObject(KonohaContext *kctx, kObject *o, const char *file, const 
 	KBuffer wb;
 	KonohaStack *lsfp = kctx->esp;
 	KLIB KBuffer_Init(&(kctx->stack->cwb), &wb);
-	KUnsafeFieldSet(lsfp[0].asObject, o);
+	KStackSetObjectValue(lsfp[0].asObject, o);
 	kObject_class(o)->format(kctx, lsfp, 0, &wb);
 	const char *msg = KLIB KBuffer_text(kctx, &wb, EnsureZero);
 	if(file == NULL) {
@@ -773,10 +773,10 @@ static void PushParam(KonohaContext *kctx, KonohaStack *sfp, const char *fmt, va
 {
 	switch(fmt[0]) {
 	case 'u': case 'i': case 'd':
-		sfp[0].unboxValue = (uintptr_t)va_arg(ap, uintptr_t);
+		KStackSetUnboxValue(sfp[0].unboxValue, (uintptr_t)va_arg(ap, uintptr_t));
 		break;
 	case 'O':
-		KUnsafeFieldSet(sfp[0].asObject, (kObject *)va_arg(ap, kObject *));
+		KStackSetObjectValue(sfp[0].asObject, (kObject *)va_arg(ap, kObject *));
 		break;
 	}
 }
@@ -790,7 +790,7 @@ static uintptr_t ApplySystemFunc(KonohaContext *kctx, uintptr_t defval, const ch
 	if(mtd != NULL) {
 		KClass *returnType = kMethod_GetReturnType(mtd);
 		BEGIN_UnusedStack(lsfp);
-		KUnsafeFieldSet(lsfp[0].asNameSpace, ns);
+		KStackSetObjectValue(lsfp[0].asNameSpace, ns);
 		for(i = 0; i < psize; i++) {
 			va_list ap;
 			va_start(ap, param);

--- a/src/konoha/import/methods.h
+++ b/src/konoha/import/methods.h
@@ -35,24 +35,22 @@ static KMETHOD Object_to(KonohaContext *kctx, KonohaStack *sfp)
 {
 	KClass *selfClass = kObject_class(sfp[0].asObject), *targetClass = KGetReturnType(sfp);
 	if(selfClass == targetClass || selfClass->isSubType(kctx, selfClass, targetClass)) {
-		sfp[K_RTNIDX].unboxValue = kObject_Unbox(sfp[0].asObject);
+		KStackSetUnboxValue(sfp[K_RTNIDX].unboxValue, kObject_Unbox(sfp[0].asObject));
 		KReturnField(sfp[0].asObject);
 	}
 	else {
 		kNameSpace *ns = KGetLexicalNameSpace(sfp);
 		DBG_ASSERT(IS_NameSpace(ns));
 		kMethod *mtd = KLIB kNameSpace_GetCoercionMethodNULL(kctx, ns, selfClass, targetClass);
-//		DBG_P("BEFORE >>>>>>>>>>> %lld\n", sfp[0].unboxValue);
-		sfp[0].unboxValue = kObject_Unbox(sfp[0].asObject);
-//		DBG_P("AFTER >>>>>>>>>>> %lld\n", sfp[0].unboxValue);
+		KStackSetUnboxValue(sfp[0].unboxValue, kObject_Unbox(sfp[0].asObject));
 		if(mtd != NULL && sfp[K_MTDIDX].calledMethod != mtd /* to avoid infinite loop */) {
-			sfp[K_MTDIDX].calledMethod = mtd;
+			KStackSetUnboxValue(sfp[K_MTDIDX].calledMethod, mtd);
 			mtd->invokeKMethodFunc(kctx, sfp);
 			return;
 		}
 	}
 	kObject *returnValue = KLIB Knull(kctx, targetClass);
-	sfp[K_RTNIDX].unboxValue = kObject_Unbox(returnValue);
+	KStackSetUnboxValue(sfp[K_RTNIDX].unboxValue, kObject_Unbox(returnValue));
 	KReturnField(returnValue);
 }
 
@@ -67,11 +65,9 @@ static KMETHOD Object_toString(KonohaContext *kctx, KonohaStack *sfp)
 		kNameSpace *ns = KGetLexicalNameSpace(sfp);
 		DBG_ASSERT(IS_NameSpace(ns));
 		kMethod *mtd = KLIB kNameSpace_GetCoercionMethodNULL(kctx, ns, kObject_class(self), KClass_String);
-//		DBG_P("BEFORE >>>>>>>>>>> %s %lld\n", KType_text(kObject_typeId(self)), sfp[0].unboxValue);
-		sfp[0].unboxValue = kObject_Unbox(self);
-//		DBG_P("AFTER >>>>>>>>>>> %lld\n", sfp[0].unboxValue);
+		KStackSetUnboxValue(sfp[0].unboxValue, kObject_Unbox(self));
 		if(mtd != NULL && sfp[K_MTDIDX].calledMethod != mtd /* to avoid infinite loop */) {
-			sfp[K_MTDIDX].calledMethod = mtd;
+			KStackSetUnboxValue(sfp[K_MTDIDX].calledMethod, mtd);
 			mtd->invokeKMethodFunc(kctx, sfp);
 			return;
 		}
@@ -274,7 +270,7 @@ static KMETHOD String_opNEQ(KonohaContext *kctx, KonohaStack *sfp)
 static KMETHOD Func_new(KonohaContext *kctx, KonohaStack *sfp)
 {
 	kFuncVar *fo = (kFuncVar *)sfp[0].asFunc;
-//	KFieldSet(fo, fo->self, sfp[1].asObject);
+	//KFieldSet(fo, fo->self, sfp[1].asObject);
 	KFieldSet(fo, fo->method,  sfp[2].asMethod);
 	KReturn(fo);
 }
@@ -284,7 +280,7 @@ static KMETHOD Func_invoke(KonohaContext *kctx, KonohaStack *sfp)
 {
 	kFunc* fo = sfp[0].asFunc;
 	DBG_ASSERT(IS_Func(fo));
-//	KUnsafeFieldSet(sfp[0].asObject, fo->self);
+	//KStackSetObjectValue(sfp[0].asObject, fo->self);
 
 	KStackCallAgain(sfp, fo->method);
 }

--- a/src/module-devel/Bash/Bash.c
+++ b/src/module-devel/Bash/Bash.c
@@ -343,14 +343,14 @@ static void BashBuilder_EmitKonohaValue(KonohaContext *kctx, KBuilder *builder, 
 static void BashBuilder_EmitConstValue(KonohaContext *kctx, KBuilder *builder, kObject *obj)
 {
 	KonohaStack sfp[1];
-	sfp[0].asObject = obj;
+	KStackSetObjectValue(sfp[0].asObject, obj);
 	BashBuilder_EmitKonohaValue(kctx, builder, kObject_class(obj), sfp);
 }
 
 static void BashBuilder_EmitUnboxConstValue(KonohaContext *kctx, KBuilder *builder, KClass *ct, unsigned long long unboxVal)
 {
 	KonohaStack sfp[1];
-	sfp[0].unboxValue = unboxVal;
+	KStackSetUnboxValue(sfp[0].unboxValue, unboxVal);
 	BashBuilder_EmitKonohaValue(kctx, builder, ct, sfp);
 }
 

--- a/src/module/Event/Http/Http.c
+++ b/src/module/Event/Http/Http.c
@@ -119,7 +119,7 @@ static RawEvent* dequeueRawEventFromLocalQueue(LocalQueue *queue)
 //			kFunc *handler_func = (kFunc *)ctx->sighandlers[ctx->signal];
 //			if(handler_func != NULL) {
 //				ksfp_t *lsfp = ctx->esp + 1; // for safety
-//				lsfp[K_CALLDELTA + 1].ivalue = ctx->signal;
+//				KStackSetUnboxValue(lsfp[K_CALLDELTA + 1].intValue, ctx->signal);
 //				knh_Func_invoke(ctx, handler_func, lsfp, 1/* argc */);
 //			}
 //		}

--- a/src/module/Event/Signal/Signal.c
+++ b/src/module/Event/Signal/Signal.c
@@ -114,7 +114,7 @@ static RawEvent* dequeueRawEventFromLocalQueue(LocalQueue *queue)
 //			kFunc *handler_func = (kFunc *)ctx->sighandlers[ctx->signal];
 //			if(handler_func != NULL) {
 //				ksfp_t *lsfp = ctx->esp + 1; // for safety
-//				lsfp[K_CALLDELTA + 1].ivalue = ctx->signal;
+//				KStackSetUnboxValue(lsfp[K_CALLDELTA + 1].intValue, ctx->signal);
 //				knh_Func_invoke(ctx, handler_func, lsfp, 1/* argc */);
 //			}
 //		}

--- a/src/module/ExecutionEngine/FuelVM/FuelVM.c
+++ b/src/module/ExecutionEngine/FuelVM/FuelVM.c
@@ -128,9 +128,9 @@ static void CallMethod(KonohaContext *kctx, kMethod *Mtd, uchar ParamSize, kObje
 	KonohaStack *stack_top = kctx->esp - ParamSize;
 	KonohaStack *sfp = stack_top + K_CALLDELTA;
 	((KonohaContextVar *)kctx)->esp = sfp + ParamSize;
-	sfp[K_MTDIDX].calledMethod = Mtd;
-	sfp[K_RTNIDX].calledFileLine = uline;
-	KUnsafeFieldSet(sfp[K_RTNIDX].asObject, object);
+	KStackSetUnboxValue(sfp[K_MTDIDX].calledMethod, Mtd);
+	KStackSetUnboxValue(sfp[K_RTNIDX].calledFileLine, uline);
+	KStackSetObjectValue(sfp[K_RTNIDX].asObject, object);
 	Mtd->invokeKMethodFunc(kctx, sfp);
 	//if(IsUnboxed)
 	//	Val.ival = sfp[K_RTNIDX].intValue;
@@ -143,14 +143,14 @@ static void CallMethod(KonohaContext *kctx, kMethod *Mtd, uchar ParamSize, kObje
 static void PushUnboxedValue(KonohaContext *kctx, SValue Val)
 {
 	KonohaStack *sp = kctx->esp;
-	sp[0+K_CALLDELTA].unboxValue = Val.bits;
+	KStackSetUnboxValue(sp[0+K_CALLDELTA].unboxValue, Val.bits);
 	((KonohaContextVar *)kctx)->esp = kctx->esp + 1;
 }
 
 static void PushBoxedValue(KonohaContext *kctx, SValue Val)
 {
 	KonohaStack *sp = kctx->esp;
-	sp[0+K_CALLDELTA].asObject   = (kObject *) Val.ptr;
+	KStackSetObjectValue(sp[0+K_CALLDELTA].asObject, (kObject *) Val.ptr);
 	((KonohaContextVar *)kctx)->esp = kctx->esp + 1;
 }
 
@@ -172,7 +172,7 @@ static SValue PopBoxedValue(KonohaContext *kctx)
 
 static void RaiseError(KonohaContext *kctx, KonohaStack *sfp, kString *ErrorInfo, int exception, int fault, kfileline_t uline)
 {
-	sfp[K_RTNIDX].calledFileLine = uline;
+	KStackSetUnboxValue(sfp[K_RTNIDX].calledFileLine, uline);
 	KLIB KRuntime_raise(kctx, exception, fault, ErrorInfo, sfp);
 }
 

--- a/src/module/ExecutionEngine/FuelVM/Optmizer.c
+++ b/src/module/ExecutionEngine/FuelVM/Optmizer.c
@@ -366,21 +366,21 @@ static INode *FoldICall(FuelIRBuilder *builder, ICall *Inst)
 	enum TypeId Type = ToUnBoxType(Inst->base.Type);
 	KClass  *kclass = KClass_(ToKType(kctx, Type));
 	kObject *DefObj = KLIB Knull(kctx, kclass);
-	KUnsafeFieldSet(lsfp[K_RTNIDX].asObject, DefObj);
-	lsfp[K_RTNIDX].unboxValue = kObject_Unbox(DefObj);
+	KStackSetObjectValue(lsfp[K_RTNIDX].asObject, DefObj);
+	KStackSetUnboxValue(lsfp[K_RTNIDX].unboxValue, kObject_Unbox(DefObj));
 
 	FOR_EACH_ARRAY__(Inst->Params, x, i, 1) {
 		IConstant *C = (IConstant *) *x;
 		if(IsUnBoxedType(C->base.Type)) {
-			lsfp[i-1].unboxValue = C->Value.bits;
+			KStackSetUnboxValue(lsfp[i-1].unboxValue, C->Value.bits);
 		} else {
-			KUnsafeFieldSet(lsfp[i-1].asObject, C->Value.obj);
-			lsfp[i-1].unboxValue = kObject_Unbox(C->Value.obj);
+			KStackSetObjectValue(lsfp[i-1].asObject, C->Value.obj);
+			KStackSetUnboxValue(lsfp[i-1].unboxValue, kObject_Unbox(C->Value.obj));
 		}
 	}
 	if(Inst->Op == VirtualCall) {
 		kNameSpace *ns = builder->Method->ns;
-		KUnsafeFieldSet(lsfp[K_NSIDX].asNameSpace, ns);
+		KStackSetObjectValue(lsfp[K_NSIDX].asNameSpace, ns);
 	}
 	KStackSetMethodAll(lsfp, DefObj, Inst->uline, mtd, psize);
 	KStackCall(lsfp);

--- a/src/module/ExecutionEngine/JavaScript/JavaScript.cpp
+++ b/src/module/ExecutionEngine/JavaScript/JavaScript.cpp
@@ -453,14 +453,14 @@ static void JSBuilder_EmitKonohaValue(KonohaContext *kctx, KBuilder *builder, KC
 static void JSBuilder_EmitConstValue(KonohaContext *kctx, KBuilder *builder, kObject *obj)
 {
 	KonohaStack sfp[1];
-	sfp[0].asObject = obj;
+	KStackSetObjectValue(sfp[0].asObject, obj);
 	JSBuilder_EmitKonohaValue(kctx, builder, kObject_class(obj), sfp);
 }
 
 static void JSBuilder_EmitUnboxConstValue(KonohaContext *kctx, KBuilder *builder, KClass *ct, unsigned long long unboxVal)
 {
 	KonohaStack sfp[1];
-	sfp[0].unboxValue = unboxVal;
+	KStackSetUnboxValue(sfp[0].unboxValue, unboxVal);
 	JSBuilder_EmitKonohaValue(kctx, builder, ct, sfp);
 }
 

--- a/src/module/ExecutionEngine/MiniVM/MiniVM.c
+++ b/src/module/ExecutionEngine/MiniVM/MiniVM.c
@@ -170,8 +170,8 @@ static void kNameSpace_LookupMethodWithInlineCache(KonohaContext *kctx, KonohaSt
 		mtd =  KLIB kNameSpace_GetMethodBySignatureNULL(kctx, ns, ct, mtd->mn, mtd->paramdom, 0, NULL);
 		cache[0] = mtd;
 	}
-	sfp[0].unboxValue = kObject_Unbox(sfp[0].asObject);
-	sfp[K_MTDIDX].calledMethod = mtd;
+	KStackSetUnboxValue(sfp[0].unboxValue, kObject_Unbox(sfp[0].asObject));
+	KStackSetUnboxValue(sfp[K_MTDIDX].calledMethod, mtd);
 }
 
 static KVirtualCode *KonohaVirtualMachine_Run(KonohaContext *, KonohaStack *, KVirtualCode *);

--- a/src/package-devel/JavaScript.Prototype/Prototype_glue.c
+++ b/src/package-devel/JavaScript.Prototype/Prototype_glue.c
@@ -121,7 +121,7 @@ static void KStackDynamicTypeCheck(KonohaContext *kctx, KonohaStack *sfp, kMetho
 		paramType = paramType->realtype(kctx, paramType, thisClass);
 		if(objectType == paramType || objectType->isSubType(kctx, objectType, paramType)) {
 			if(KClass_Is(UnboxType, paramType)) {
-				sfp[i+1].unboxValue = kObject_Unbox(sfp[i+1].asObject);
+				KStackSetUnboxValue(sfp[i+1].unboxValue, kObject_Unbox(sfp[i+1].asObject));
 			}
 			continue; // OK
 		}

--- a/src/package-devel/JavaStyle.Object/Object_glue.c
+++ b/src/package-devel/JavaStyle.Object/Object_glue.c
@@ -24,6 +24,7 @@
 
 #include <konoha3/konoha.h>
 #include <konoha3/sugar.h>
+#include <konoha3/import/methoddecl.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -53,11 +54,9 @@ static KMETHOD Object_as(KonohaContext *kctx, KonohaStack *sfp)
 	else {
 		returnValue = KLIB Knull(kctx, targetClass);
 	}
-	sfp[K_RTNIDX].unboxValue = kObject_Unbox(returnValue);
+	KStackSetUnboxValue(sfp[K_RTNIDX].unboxValue, kObject_Unbox(returnValue));
 	KReturn(returnValue);
 }
-
-#include <konoha3/import/methoddecl.h>
 
 static void object_defineMethod(KonohaContext *kctx, kNameSpace *ns, KTraceInfo *trace)
 {

--- a/src/package-devel/Lib.Libevent/Libevent_glue.c
+++ b/src/package-devel/Lib.Libevent/Libevent_glue.c
@@ -137,10 +137,10 @@ static void cevent_CB_method_invoke(evutil_socket_t evd, short event, void *arg)
 
 	BEGIN_UnusedStack(lsfp);
 	KClass *returnType = kMethod_GetReturnType(ev->kcb->method);
-	KUnsafeFieldSet(lsfp[0].asObject, K_NULL);
-	lsfp[1].intValue = evd;
-	lsfp[2].intValue = event;
-	KUnsafeFieldSet(lsfp[3].asObject, ev->kcbArg);
+	KStackSetObjectValue(lsfp[0].asObject, K_NULL);
+	KStackSetUnboxValue(lsfp[1].intValue, evd);
+	KStackSetUnboxValue(lsfp[2].intValue, event);
+	KStackSetObjectValue(lsfp[3].asObject, ev->kcbArg);
 
 	KStackSetFuncAll(lsfp, KLIB Knull(kctx, returnType), 0/*UL*/, ev->kcb, 3);
 	KStackCall(lsfp);
@@ -266,7 +266,7 @@ static KMETHOD cevent_event_add(KonohaContext *kctx, KonohaStack* sfp)
 {
 	kcevent *kcev = (kcevent *)sfp[0].asObject;
 	kctimeval *tv = (kctimeval *)sfp[1].asObject;
-	KUnsafeFieldSet(kcev->kctimeval, tv);
+	KStackSetObjectValue(kcev->kctimeval, tv);
 	int ret = event_add(kcev->event, tvIsNull(tv) ? NULL : &tv->timeval);
 	KReturnUnboxValue(ret);
 }
@@ -275,7 +275,7 @@ static KMETHOD cevent_event_add(KonohaContext *kctx, KonohaStack* sfp)
 static KMETHOD cevent_event_del(KonohaContext *kctx, KonohaStack* sfp)
 {
 	kcevent *kcev = (kcevent *)sfp[0].asObject;
-	KUnsafeFieldInit(kcev->kctimeval, K_NULL);	//delete reference
+	KFieldSet(kcev, kcev->kctimeval, K_NULL);	//delete reference
 	int ret = event_del(kcev->event);
 	KReturnUnboxValue(ret);
 }
@@ -381,9 +381,9 @@ static void Cbev_dataCB_dispatcher(kFunc *datacb, struct bufferevent *bev, void 
 
 	BEGIN_UnusedStack(lsfp);
 	KClass *returnType = kMethod_GetReturnType(datacb->method);
-	KUnsafeFieldSet(lsfp[0].asObject, K_NULL/*(kObject *)kcbev*/);
-	KUnsafeFieldSet(lsfp[1].asObject, (kObject *)kcbev);
-	KUnsafeFieldSet(lsfp[2].asObject, kcbev->kcbArg);
+	KStackSetObjectValue(lsfp[0].asObject, K_NULL/*(kObject *)kcbev*/);
+	KStackSetObjectValue(lsfp[1].asObject, (kObject *)kcbev);
+	KStackSetObjectValue(lsfp[2].asObject, kcbev->kcbArg);
 	KStackSetFuncAll(lsfp, KLIB Knull(kctx, returnType), 0/*UL*/, datacb, 2);
 	KStackCall(lsfp);
 	END_UnusedStack();
@@ -418,10 +418,10 @@ static void cbev_eventCB_method_invoke(struct bufferevent *bev, short what, void
 
 	BEGIN_UnusedStack(lsfp);
 	KClass *returnType = kMethod_GetReturnType(kcbev->eventcb->method);
-	KUnsafeFieldSet(lsfp[0].asObject, K_NULL);
-	KUnsafeFieldSet(lsfp[1].asObject, (kObject *)kcbev);
-	lsfp[2].intValue = what;
-	KUnsafeFieldSet(lsfp[3].asObject, (kObject *)kcbev->kcbArg);
+	KStackSetObjectValue(lsfp[0].asObject, K_NULL);
+	KStackSetObjectValue(lsfp[1].asObject, (kObject *)kcbev);
+	KStackSetUnboxValue(lsfp[2].intValue, what);
+	KStackSetObjectValue(lsfp[3].asObject, (kObject *)kcbev->kcbArg);
 	KStackSetFuncAll(lsfp, KLIB Knull(kctx, returnType), 0/*UL*/, kcbev->eventcb, 3);
 	KStackCall(lsfp);
 	END_UnusedStack();

--- a/src/package-devel/MiniKonoha.EventListener/EventListener_glue.c
+++ b/src/package-devel/MiniKonoha.EventListener/EventListener_glue.c
@@ -416,14 +416,14 @@ static KMETHOD System_SetSafepoint(KonohaContext *kctx, KonohaStack *sfp)
 //## void System.setEventInvokeFunc(Func f);
 static KMETHOD System_SetEventInvokeFunc(KonohaContext *kctx, KonohaStack *sfp)
 {
-	KonohaContext_getEventContext(kctx)->invokeFuncNULL = sfp[1].asFunc;
+	KUnsafeFieldSet(KonohaContext_getEventContext(kctx)->invokeFuncNULL, sfp[1].asFunc);
 	KReturnVoid();
 }
 
 //## void System.setEnqFunc(Func f);
 static KMETHOD System_SetEnqFunc(KonohaContext *kctx, KonohaStack *sfp)
 {
-	KonohaContext_getEventContext(kctx)->enqFuncNULL = sfp[1].asFunc;
+	KUnsafeFieldSet(KonohaContext_getEventContext(kctx)->enqFuncNULL, sfp[1].asFunc);
 	KReturnVoid();
 }
 
@@ -435,8 +435,8 @@ static void enqueueEventToGlobalQueue(KonohaContext *kctx, RawEvent rawEvent)
 	ev->j = (json_t *)rawEvent;
 	KClass *returnType = kMethod_GetReturnType(KonohaContext_getEventContext(kctx)->enqFuncNULL->method);
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[0].asObject, K_NULL);
-	KUnsafeFieldSet(lsfp[1].asObject, (kObject *)ev);
+	KStackSetObjectValue(lsfp[0].asObject, K_NULL);
+	KStackSetObjectValue(lsfp[1].asObject, (kObject *)ev);
 	KStackSetFuncAll(lsfp, KLIB Knull(kctx, returnType), 0/*UL*/, KonohaContext_getEventContext(kctx)->enqFuncNULL, 1);
 	KStackCall(lsfp);
 	END_UnusedStack();

--- a/src/package-devel/MiniKonoha.Sql/sql_glue.c
+++ b/src/package-devel/MiniKonoha.Sql/sql_glue.c
@@ -185,7 +185,8 @@ static void kResultSet_format(KonohaContext *kctx, KonohaValue *v, int pos, KBuf
 		ktypeattr_t type = rs->column[i].type;
 		krbp_t *val = &rs->column[i].val;
 		if(KType_Is(UnboxType, type)) {
-			KonohaValue sp[1]; sp[0].unboxValue = val[0].unboxValue;
+			KonohaValue sp[1];
+			KStackSetUnboxValue(sp[0].unboxValue, val[0].unboxValue);
 			KClass_(type)->format(kctx, sp, 0, wb);
 		} else {
 			KLIB kObject_WriteToBuffer(kctx, val[0].asObject, false/*delim*/, wb, NULL, 0);
@@ -489,7 +490,7 @@ static KMETHOD ResultSet_get(KonohaContext *kctx, KonohaStack *sfp)
 		ResultSet_getFloat(kctx, sfp);
 	} else {
 		kObject *returnValue = KLIB Knull(kctx, retClass);
-		sfp[K_RTNIDX].unboxValue = kObject_Unbox(returnValue);
+		KStackSetUnboxValue(sfp[K_RTNIDX].unboxValue, kObject_Unbox(returnValue));
 		KReturn(returnValue);
 	}
 }

--- a/src/package-devel/Type.Dynamic/Dynamic_glue.c
+++ b/src/package-devel/Type.Dynamic/Dynamic_glue.c
@@ -57,7 +57,7 @@ static kbool_t kMethod_CheckMethodKStackCall(KonohaContext *kctx, KonohaStack *s
 			return false;
 		}
 		if(KClass_Is(UnboxType, paramClass)) {
-			sfp[i].unboxValue = kObject_Unbox(sfp[i].asObject);
+			KStackSetUnboxValue(sfp[i].unboxValue, kObject_Unbox(sfp[i].asObject));
 		}
 	}
 	return true;
@@ -77,7 +77,7 @@ static KMETHOD Dynamic_(KonohaContext *kctx, KonohaStack *sfp)
 	if(mtd != NULL) {
 		if(kMethod_CheckMethodKStackCall(kctx, sfp, mtd, argc)) {
 			KStackSetArgc(sfp, argc);
-			sfp[K_MTDIDX].calledMethod = mtd;
+			KStackSetUnboxValue(sfp[K_MTDIDX].calledMethod, mtd);
 			//kObject *returnValue = sfp[K_RTNIDX].asObject;
 			KStackCall(sfp);
 			return;

--- a/src/package/JavaScript.Array/Array_glue.c
+++ b/src/package/JavaScript.Array/Array_glue.c
@@ -263,8 +263,8 @@ static KMETHOD Array_reverse(KonohaContext *kctx, KonohaStack *sfp)
 //		for(i=0; i != asize; ++i) {
 //			uintptr_t tmp = a->unboxItems[i];
 //			BEGIN_UnusedStack(lsfp, K_CALLDELTA + 1);
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+0].asObject, K_NULL);
-//			lsfp[K_CALLDELTA+1].unboxValue = tmp;
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+0].asObject, K_NULL);
+//			KStackSetUnboxValue(lsfp[K_CALLDELTA+1].unboxValue, tmp);
 //			{
 //				KonohaStack *sfp = lsfp + K_CALLDELTA;
 //				KStackSetMethodAll(sfp, 0/*UL*/, f->mtd, 1, KLIB Knull(kctx, KClass_(resolve_type)));
@@ -278,8 +278,8 @@ static KMETHOD Array_reverse(KonohaContext *kctx, KonohaStack *sfp)
 //		for(i=0; i != asize; ++i) {
 //			kObject *tmp  = a->ObjectItems[i];
 //			BEGIN_UnusedStack(lsfp, K_CALLDELTA + 1);
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+0].asObject, K_NULL);
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+1].asObject, tmp);
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+0].asObject, K_NULL);
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+1].asObject, tmp);
 //			{
 //				KonohaStack *sfp = lsfp + K_CALLDELTA;
 //				KStackSetMethodAll(sfp, 0/*UL*/, f->mtd, 1, KLIB Knull(kctx, KClass_(resolve_type)));
@@ -306,9 +306,9 @@ static KMETHOD Array_reverse(KonohaContext *kctx, KonohaStack *sfp)
 //		uintptr_t tmp = 0;
 //		BEGIN_UnusedStack(lsfp, K_CALLDELTA + 2);
 //		for(i=0; i != asize; ++i) {
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+0].asObject, K_NULL);
-//			lsfp[K_CALLDELTA+1].unboxValue = tmp;
-//			lsfp[K_CALLDELTA+2].unboxValue = a->unboxItems[i];
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+0].asObject, K_NULL);
+//			KStackSetUnboxValue(lsfp[K_CALLDELTA+1].unboxValue, tmp);
+//			KStackSetUnboxValue(lsfp[K_CALLDELTA+2].unboxValue, a->unboxItems[i]);
 //			{
 //				KonohaStack *sfp = lsfp + K_CALLDELTA;
 //				KStackSetMethodAll(sfp, 0/*UL*/, f->mtd, 2, KLIB Knull(kctx, KClass_(resolve_type)));
@@ -325,15 +325,15 @@ static KMETHOD Array_reverse(KonohaContext *kctx, KonohaStack *sfp)
 //		kObject *nulobj = KLIB Knull(kctx, KClass_(resolve_type));
 //		BEGIN_UnusedStack(lsfp, K_CALLDELTA + 2);
 //		for(i=0; i != asize; ++i) {
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+0].asObject, nulobj);
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+1].asObject, tmp);
-//			KUnsafeFieldSet(lsfp[K_CALLDELTA+2].asObject, a->ObjectItems[i]);
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+0].asObject, nulobj);
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+1].asObject, tmp);
+//			KStackSetObjectValue(lsfp[K_CALLDELTA+2].asObject, a->ObjectItems[i]);
 //			{
 //				KonohaStack *sfp = lsfp + K_CALLDELTA;
 //				KStackSetMethodAll(sfp, 0/*UL*/, f->mtd, 2, nulobj);
 //				KStackCall(sfp);
 //			}
-//			KUnsafeFieldSet(tmp, lsfp[0].asObject);
+//			tmp = lsfp[0].asObject; /* FIXME(ide) I think, it is dangerous but I don't know how to fix it. */
 //		}
 //		END_UnusedStack();
 //		KReturnWith(tmp, RESET_GCSTACK());
@@ -419,23 +419,23 @@ static void kArray_join(KonohaContext *kctx, KBuffer *wb, kArray *a, const char 
 	KClass *KClass_p0 = KClass_(kObject_p0(a));
 	if(kArray_Is(UnboxData, a)) {
 		for(i = 0; i < asize - 1; i++) {
-			lsfp[0].unboxValue = a->unboxItems[i];
+			KStackSetUnboxValue(lsfp[0].unboxValue, a->unboxItems[i]);
 			KClass_p0->format(kctx, lsfp, 0, wb);
 			KLIB KBuffer_Write(kctx, wb, separator, length);
 		}
 		if(asize > 0) {
-			lsfp[0].unboxValue = a->unboxItems[asize - 1];
+			KStackSetUnboxValue(lsfp[0].unboxValue, a->unboxItems[asize - 1]);
 			KClass_p0->format(kctx, lsfp, 0, wb);
 		}
 	}
 	else {
 		for(i = 0; i < asize - 1; i++) {
-			KUnsafeFieldSet(lsfp[0].asObject, a->ObjectItems[i]);
+			KStackSetObjectValue(lsfp[0].asObject, a->ObjectItems[i]);
 			KClass_p0->format(kctx, lsfp, 0, wb);
 			KLIB KBuffer_Write(kctx, wb, separator, length);
 		}
 		if(asize > 0) {
-			KUnsafeFieldSet(lsfp[0].asObject, a->ObjectItems[asize - 1]);
+			KStackSetObjectValue(lsfp[0].asObject, a->ObjectItems[asize - 1]);
 			KClass_p0->format(kctx, lsfp, 0, wb);
 		}
 	}

--- a/src/package/MiniKonoha.Syntax/Syntax_glue.c
+++ b/src/package/MiniKonoha.Syntax/Syntax_glue.c
@@ -435,7 +435,8 @@ static KMETHOD Node_AppendParsedNode(KonohaContext *kctx, KonohaStack *sfp)
 	kArray *tokenList = sfp[1].asArray;
 	int beginIdx = sfp[2].intValue;
 	int endIdx = sfp[3].intValue;
-	const char *requiredTokenText = IS_NULL(sfp[4].asString) ? NULL : kString_text(sfp[4].asString);
+	kString *str = sfp[4].asString;
+	const char *requiredTokenText = IS_NULL(str) ? NULL : kString_text(str);
 	KReturn(SUGAR AppendParsedNode(kctx, node, tokenList, beginIdx, endIdx, NULL, ParseExpressionOption, requiredTokenText));
 }
 

--- a/src/package/Syntax.JavaStyleClass/JavaStyleClass_glue.c
+++ b/src/package/Syntax.JavaStyleClass/JavaStyleClass_glue.c
@@ -51,9 +51,9 @@ static kNode *CallTypeFunc(KonohaContext *kctx, kFunc *fo, kNode *expr, kNameSpa
 {
 	INIT_GCSTACK();
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[1].asNode, expr);
-	KUnsafeFieldSet(lsfp[2].asNameSpace, ns);
-	KUnsafeFieldSet(lsfp[3].asObject, reqType);
+	KStackSetObjectValue(lsfp[1].asNode, expr);
+	KStackSetObjectValue(lsfp[2].asNameSpace, ns);
+	KStackSetObjectValue(lsfp[3].asObject, reqType);
 	CallSugarMethod(kctx, lsfp, fo, 4, UPCAST(K_NULLNODE));
 	END_UnusedStack();
 	RESET_GCSTACK();

--- a/src/package/Type.Float/Float_glue.c
+++ b/src/package/Type.Float/Float_glue.c
@@ -303,7 +303,8 @@ static KMETHOD TypeCheck_Float(KonohaContext *kctx, KonohaStack *sfp)
 {
 	VAR_TypeCheck2(stmt, expr, ns, reqc);
 	kToken *tk = expr->TermToken;
-	sfp[4].floatValue = strtod(kString_text(tk->text), NULL);   // just using tramsformation float
+	// just using tramsformation float
+	KStackSetUnboxValue(sfp[4].floatValue, strtod(kString_text(tk->text), NULL));
 	KReturn(SUGAR kNode_SetUnboxConst(kctx, expr, KType_float, sfp[4].unboxValue));
 }
 

--- a/src/parser/import/ast.h
+++ b/src/parser/import/ast.h
@@ -29,12 +29,12 @@ typedef enum {
 static int CallParseFunc(KonohaContext *kctx, kFunc *fo, kNode *node, ksymbol_t symbol, kArray *tokenList, int beginIdx, int operatorIdx, int endIdx)
 {
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[1].asNode, node);
-	lsfp[2].intValue = symbol;
-	KUnsafeFieldSet(lsfp[3].asArray, tokenList);
-	lsfp[4].intValue = beginIdx;
-	lsfp[5].intValue = operatorIdx;
-	lsfp[6].intValue = endIdx;
+	KStackSetObjectValue(lsfp[1].asNode, node);
+	KStackSetUnboxValue(lsfp[2].intValue, symbol);
+	KStackSetObjectValue(lsfp[3].asArray, tokenList);
+	KStackSetUnboxValue(lsfp[4].intValue, beginIdx);
+	KStackSetUnboxValue(lsfp[5].intValue, operatorIdx);
+	KStackSetUnboxValue(lsfp[6].intValue, endIdx);
 	CallSugarMethod(kctx, lsfp, fo, 6, (kObject *)KNULL(Int));
 	END_UnusedStack();
 	if(kNode_IsError(node)) return endIdx;

--- a/src/parser/import/eval.h
+++ b/src/parser/import/eval.h
@@ -39,8 +39,8 @@ static kstatus_t kMethod_RunEval(KonohaContext *kctx, kMethod *mtd, ktypeattr_t 
 	BEGIN_UnusedStack(lsfp);
 	KRuntimeContextVar *runtime = kctx->stack;
 	if(runtime->evalty != KType_void) {
-		KUnsafeFieldSet(lsfp[1].asObject, runtime->stack[runtime->evalidx].asObject);
-		lsfp[1].intValue = runtime->stack[runtime->evalidx].intValue;
+		KStackSetObjectValue(lsfp[1].asObject, runtime->stack[runtime->evalidx].asObject);
+		KStackSetUnboxValue(lsfp[1].intValue,  runtime->stack[runtime->evalidx].intValue);
 	}
 	KStackSetMethodAll(lsfp, KLIB Knull(kctx, KClass_(rtype)), uline, mtd, 1);
 	kstatus_t result = K_CONTINUE;

--- a/src/parser/import/namespace.h
+++ b/src/parser/import/namespace.h
@@ -132,8 +132,9 @@ static KMETHOD NameSpace_DefineConst(KonohaContext *kctx, KonohaStack *sfp)
 {
 	KMakeTrace(trace, sfp);
 	ksymbol_t symbol = (ksymbol_t)sfp[1].intValue;
-	KClass *c = kObject_class(sfp[2].asObject);
-	uintptr_t unboxValue = KClass_Is(UnboxType, c) ? kObject_Unbox(sfp[2].asObject) : (uintptr_t)sfp[2].asObject;
+	kObject  *value = sfp[2].asObject;
+	KClass   *c = kObject_class(value);
+	uintptr_t unboxValue = KClass_Is(UnboxType, c) ? kObject_Unbox(value) : (uintptr_t)value;
 	KReturnUnboxValue(kNameSpace_SetConstData(kctx, sfp[0].asNameSpace, symbol, c->typeId, unboxValue, trace));
 }
 

--- a/src/parser/import/parser_class.h
+++ b/src/parser/import/parser_class.h
@@ -129,12 +129,12 @@ static void kToken_format(KonohaContext *kctx, KonohaValue *v, int pos, KBuffer 
 		kArray *a = tk->GroupTokenList;
 		KLIB KBuffer_Write(kctx, wb, "[", 1);
 		if(kArray_size(a) > 0) {
-			KUnsafeFieldSet(v[pos+1].asToken, a->TokenItems[0]);
+			KStackSetObjectValue(v[pos+1].asToken, a->TokenItems[0]);
 			kToken_format(kctx, v, pos+1, wb);
 		}
 		for(i = 1; i < kArray_size(a); i++) {
 			KLIB KBuffer_Write(kctx, wb, " ", 1);
-			KUnsafeFieldSet(v[pos+1].asToken, a->TokenItems[i]);
+			KStackSetObjectValue(v[pos+1].asToken, a->TokenItems[i]);
 			kToken_format(kctx, v, pos+1, wb);
 		}
 		KLIB KBuffer_Write(kctx, wb, "]", 1);
@@ -174,7 +174,7 @@ static void kNodeTerm_format(KonohaContext *kctx, kObject *o, KonohaValue *v, in
 		KBuffer_WriteTokenText(kctx, wb, (kToken *)o);
 	}
 	else {
-		KUnsafeFieldSet(v[pos].asObject, o);
+		KStackSetObjectValue(v[pos].asObject, o);
 		kObject_class(o)->format(kctx, v, pos, wb);
 	}
 }

--- a/src/parser/import/preprocess.h
+++ b/src/parser/import/preprocess.h
@@ -254,12 +254,12 @@ static int ReplaceToken(KonohaContext *kctx, kFunc *fo, kNameSpace *ns, kArray *
 {
 	DBG_ASSERT(IS_Func(fo));
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[1].asNameSpace, ns);
-	KUnsafeFieldSet(lsfp[2].asArray, tokenList);
-	lsfp[3].unboxValue = (uintptr_t)beginIdx;
-	lsfp[4].unboxValue = (uintptr_t)beginIdx;
-	lsfp[5].unboxValue = (uintptr_t)beginIdx;
-	KUnsafeFieldSet(lsfp[6].asArray, bufferList);
+	KStackSetObjectValue(lsfp[1].asNameSpace, ns);
+	KStackSetObjectValue(lsfp[2].asArray, tokenList);
+	KStackSetUnboxValue(lsfp[3].unboxValue, (uintptr_t)beginIdx);
+	KStackSetUnboxValue(lsfp[4].unboxValue, (uintptr_t)beginIdx);
+	KStackSetUnboxValue(lsfp[5].unboxValue, (uintptr_t)beginIdx);
+	KStackSetObjectValue(lsfp[6].asArray, bufferList);
 	CallSugarMethod(kctx, lsfp, fo, 6, KLIB Knull(kctx, KClass_Int));
 	END_UnusedStack();
 	return((int)lsfp[K_RTNIDX].intValue);

--- a/src/parser/import/token.h
+++ b/src/parser/import/token.h
@@ -457,10 +457,10 @@ static int CallTokenFunc(KonohaContext *kctx, kFunc *fo, kTokenVar *tk, Tokenize
 {
 	DBG_ASSERT(IS_Func(fo));
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[0].asNameSpace, tokenizer->ns);
-	KUnsafeFieldSet(lsfp[1].asToken, tk);
-	lsfp[1].unboxValue = (uintptr_t)tokenizer;
-	KUnsafeFieldSet(lsfp[2].asString, preparedString);
+	KStackSetObjectValue(lsfp[0].asNameSpace, tokenizer->ns);
+	KStackSetObjectValue(lsfp[1].asToken, tk);
+	KStackSetUnboxValue(lsfp[1].unboxValue, (uintptr_t)tokenizer);
+	KStackSetObjectValue(lsfp[2].asString, preparedString);
 	CallSugarMethod(kctx, lsfp, fo, 2, KLIB Knull(kctx, KClass_Int));
 	END_UnusedStack();
 	int pos = lsfp[K_RTNIDX].intValue + tok_start;

--- a/src/parser/import/typecheck.h
+++ b/src/parser/import/typecheck.h
@@ -52,9 +52,9 @@ static kNode *CallTypeFunc(KonohaContext *kctx, kFunc *fo, kNode *expr, kNameSpa
 {
 	INIT_GCSTACK();
 	BEGIN_UnusedStack(lsfp);
-	KUnsafeFieldSet(lsfp[1].asNode, expr);
-	KUnsafeFieldSet(lsfp[2].asNameSpace, ns);
-	KUnsafeFieldSet(lsfp[3].asObject, reqType);
+	KStackSetObjectValue(lsfp[1].asNode, expr);
+	KStackSetObjectValue(lsfp[2].asNameSpace, ns);
+	KStackSetObjectValue(lsfp[3].asObject, reqType);
 	CallSugarMethod(kctx, lsfp, fo, 4, UPCAST(K_NULLNODE));
 	END_UnusedStack();
 	RESET_GCSTACK();
@@ -107,22 +107,22 @@ static kNode *TypeNode(KonohaContext *kctx, kSyntax *syn, kNode *expr, kNameSpac
 static void PutConstNode(KonohaContext *kctx, kNode *expr, KonohaStack *sfp)
 {
 	if(kNode_node(expr) == KNode_Const) {
-		KUnsafeFieldSet(sfp[0].asObject, expr->ObjectConstValue);
-		sfp[0].unboxValue = kObject_Unbox(expr->ObjectConstValue);
+		KStackSetObjectValue(sfp[0].asObject, expr->ObjectConstValue);
+		KStackSetUnboxValue(sfp[0].unboxValue, kObject_Unbox(expr->ObjectConstValue));
 	} else if(kNode_node(expr) == KNode_UnboxConst) {
-		sfp[0].unboxValue = expr->unboxConstValue;
+		KStackSetUnboxValue(sfp[0].unboxValue, expr->unboxConstValue);
 	} else if(kNode_node(expr) == KNode_New) {
-		KUnsafeFieldSet(sfp[0].asObject, KLIB new_kObject(kctx, OnField, KClass_(expr->attrTypeId), 0));
+		KStackSetObjectValue(sfp[0].asObject, KLIB new_kObject(kctx, OnField, KClass_(expr->attrTypeId), 0));
 //	} else if(kNode_node(expr) == KNode_MethodCall) {   /* case Object Object.boxing(UnboxType Val) */
 //		kMethod *mtd = expr->NodeList->MethodItems[0];
 //		kNode *texpr = expr->NodeList->NodeItems[1];
 //		assert(mtd->mn == MN_box && kArray_size(expr->NodeList) == 2);
 //		assert(KType_Is(UnboxType, expr->attrTypeId) == true);
-//		KUnsafeFieldSet(sfp[0].asObject, KLIB new_kObject(kctx, OnField, KClass_(expr->attrTypeId), texpr->unboxConstValue));
+//		KStackSetObjectValue(sfp[0].asObject, KLIB new_kObject(kctx, OnField, KClass_(expr->attrTypeId), texpr->unboxConstValue));
 	} else {
 		assert(kNode_node(expr) == KNode_Null);
-		KUnsafeFieldSet(sfp[0].asObject, KLIB Knull(kctx, KClass_(expr->attrTypeId)));
-		sfp[0].unboxValue = 0;
+		KStackSetObjectValue(sfp[0].asObject, KLIB Knull(kctx, KClass_(expr->attrTypeId)));
+		KStackSetUnboxValue(sfp[0].unboxValue, 0);
 	}
 }
 


### PR DESCRIPTION
Add 2 macros for control stack operation.

[Old]
  KUnsafeFieldSet(sfp[n].asObject, ObjectPtr);
  sfp[n].intValue = intValue;

[New]
  KStackSetObjectValue(sfp[n].asObject, ObjectPtr);
  KStackSetUnboxValue(sfp[n].intValue, intValue);
