### PR TITLE
ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# build directory
+/build/
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
README にしたがってビルドしたときに `git status` で `./build` が版管理候補になるので、 `.gitignore` に `build` ディレクトリを追加した。
